### PR TITLE
Update to Jasmin 2025.06.1

### DIFF
--- a/src/aegis128l/aegis128l.jazz
+++ b/src/aegis128l/aegis128l.jazz
@@ -79,7 +79,7 @@ inline fn declast(#secret reg u128[8] st, #public reg u128[2] t,
     pad[1] = out[1];
     reg u64 i = left;
     while (i < 32) {
-        pad[u8(int) i] = 0;
+        pad[:u8 i] = 0;
         i += 1;
     }
     st = update(st, pad[0], pad[1]);
@@ -96,8 +96,8 @@ inline fn init(#public reg u64 key_p, #public reg u64 nonce_p)
 
     #secret reg u128 k;
     #public reg u128 n;
-    k = (u128)[key_p];
-    #declassify n = (u128)[nonce_p];
+    k = [:u128 key_p];
+    #declassify n = [:u128 nonce_p];
 
     #secret reg u128 kn kc0;
 
@@ -127,14 +127,15 @@ inline fn finalize(#secret reg u128[8] st,
                    #public inline bool verify)
     -> #secret reg u64
 {
-    reg u64 ret = #set0();
+    reg u64 ret;
+    ?{}, ret = #set0();
 
     stack u64[2] sizes;
     ad_len <<= 3;
     msg_len <<= 3;
     sizes[0] = ad_len;
     sizes[1] = msg_len;
-    reg u128 t = st[2] ^ sizes[u128 0];
+    reg u128 t = st[2] ^ sizes[:u128 0];
 
     inline int i;
     for i = 0 to 7 {
@@ -152,14 +153,14 @@ inline fn finalize(#secret reg u128[8] st,
 
         if (verify) {
             reg u128 valid;
-            valid = (u128)[tag_p];
+            valid = [:u128 tag_p];
             valid = #VPCMPEQ_2u64(valid, tag);
-            ret = #VPMOVMSKB_u128u64(valid);
+            ret = (64u)#MOVEMASK_16u8(valid);
             ret += 1;
             ret >>= 16;
             ret -= 1;
         } else {
-            (u128)[tag_p] = tag;
+            [:u128 tag_p] = tag;
         }
     } else {
         reg u128[2] tag;
@@ -172,18 +173,18 @@ inline fn finalize(#secret reg u128[8] st,
 
         if (verify) {
             reg u128[2] valid;
-            valid[0] = (u128)[tag_p];
-            valid[1] = (u128)[tag_p + 16];
+            valid[0] = [:u128 tag_p];
+            valid[1] = [:u128 tag_p + 16];
             valid[0] = #VPCMPEQ_2u64(valid[0], tag[0]);
             valid[1] = #VPCMPEQ_2u64(valid[1], tag[1]);
             valid[0] &= valid[1];
-            ret = #VPMOVMSKB_u128u64(valid[0]);
+            ret = (64u)#MOVEMASK_16u8(valid[0]);
             ret += 1;
             ret >>= 16;
             ret -= 1;
         } else {
-            (u128)[tag_p] = tag[0];
-            (u128)[tag_p + 16] = tag[1];
+            [:u128 tag_p] = tag[0];
+            [:u128 tag_p + 16] = tag[1];
         }
     }
     for i = 0 to 8 {
@@ -199,16 +200,16 @@ export fn _aegis128l_encrypt(#public reg u64 params)
     #public stack u64 ad_len_ msg_len_;
     #public reg u8 tag_len;
 
-    #declassify ct_p = (u64)[params + 8 * 0];
-    // ignored: ct_len = (u64)[params + 8 * 1];
-    #declassify tag_p = (u64)[params + 8 * 2];
-    #declassify tag_len = (u8)[params + 8 * 3];
-    #declassify msg_p = (u64)[params + 8 * 4];
-    #declassify msg_len_ = (u64)[params + 8 * 5];
-    #declassify ad_p = (u64)[params + 8 * 6];
-    #declassify ad_len_ = (u64)[params + 8 * 7];
-    #declassify key_p = (u64)[params + 8 * 8];
-    #declassify nonce_p = (u64)[params + 8 * 9];
+    #declassify ct_p = [:u64 params + 8 * 0];
+    // ignored: ct_len = [:u64 params + 8 * 1];
+    #declassify tag_p = [:u64 params + 8 * 2];
+    #declassify tag_len = [:u8 params + 8 * 3];
+    #declassify msg_p = [:u64 params + 8 * 4];
+    #declassify msg_len_ = [:u64 params + 8 * 5];
+    #declassify ad_p = [:u64 params + 8 * 6];
+    #declassify ad_len_ = [:u64 params + 8 * 7];
+    #declassify key_p = [:u64 params + 8 * 8];
+    #declassify nonce_p = [:u64 params + 8 * 9];
 
     #secret reg u128[8] st;
     st = init(key_p, nonce_p);
@@ -219,12 +220,13 @@ export fn _aegis128l_encrypt(#public reg u64 params)
     full_blocks = ad_len_;
     full_blocks = full_blocks & -32;
 
-    reg u64 i = #set0();
+    reg u64 i;
+    ?{}, i = #set0();
 
     #align while (i < full_blocks) {
         reg u128[2] t;
-        t[0] = (u128)[ad_p + i];
-        t[1] = (u128)[ad_p + i + 16];
+        t[0] = [:u128 ad_p + i];
+        t[1] = [:u128 ad_p + i + 16];
         st = absorb(st, t);
         i += 32;
     }
@@ -240,9 +242,9 @@ export fn _aegis128l_encrypt(#public reg u64 params)
         pad[0] = zero;
         pad[1] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[ad_p + i];
+            pad[:u8 i] = [:u8 ad_p + i];
             i += 1;
         }
 
@@ -258,15 +260,15 @@ export fn _aegis128l_encrypt(#public reg u64 params)
     full_blocks = msg_len_;
     full_blocks = full_blocks & -32;
 
-    i = #set0();
+    ?{}, i = #set0();
     #align while (i < full_blocks) {
         reg u128[2] t;
-        t[0] = (u128)[msg_p + i];
-        t[1] = (u128)[msg_p + i + 16];
+        t[0] = [:u128 msg_p + i];
+        t[1] = [:u128 msg_p + i + 16];
         reg u128[2] out;
         st, out = enc(st, t);
-        (u128)[ct_p + i] = out[0];
-        (u128)[ct_p + i + 16] = out[1];
+        [:u128 ct_p + i] = out[0];
+        [:u128 ct_p + i + 16] = out[1];
         i += 32;
     }
 
@@ -281,9 +283,9 @@ export fn _aegis128l_encrypt(#public reg u64 params)
         pad[0] = zero;
         pad[1] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[msg_p + i];
+            pad[:u8 i] = [:u8 msg_p + i];
             i += 1;
         }
 
@@ -296,9 +298,9 @@ export fn _aegis128l_encrypt(#public reg u64 params)
         pad[0] = out[0];
         pad[1] = out[1];
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            (u8)[ct_p + i] = pad[u8(int) i];
+            [:u8 ct_p + i] = pad[:u8 i];
             i += 1;
         }
     }
@@ -317,16 +319,16 @@ export fn _aegis128l_decrypt(#public reg u64 params)
     #public stack u64 ad_len_ ct_len_;
     #public reg u8 tag_len;
 
-    #declassify ct_p = (u64)[params + 8 * 0];
-    #declassify ct_len_ = (u64)[params + 8 * 1];
-    #declassify tag_p = (u64)[params + 8 * 2];
-    #declassify tag_len = (u8)[params + 8 * 3];
-    #declassify msg_p = (u64)[params + 8 * 4];
-    // ignored: msg_len_ = (u64)[params + 8 * 5];
-    #declassify ad_p = (u64)[params + 8 * 6];
-    #declassify ad_len_ = (u64)[params + 8 * 7];
-    #declassify key_p = (u64)[params + 8 * 8];
-    #declassify nonce_p = (u64)[params + 8 * 9];
+    #declassify ct_p = [:u64 params + 8 * 0];
+    #declassify ct_len_ = [:u64 params + 8 * 1];
+    #declassify tag_p = [:u64 params + 8 * 2];
+    #declassify tag_len = [:u8 params + 8 * 3];
+    #declassify msg_p = [:u64 params + 8 * 4];
+    // ignored: msg_len_ = [:u64 params + 8 * 5];
+    #declassify ad_p = [:u64 params + 8 * 6];
+    #declassify ad_len_ = [:u64 params + 8 * 7];
+    #declassify key_p = [:u64 params + 8 * 8];
+    #declassify nonce_p = [:u64 params + 8 * 9];
 
     #secret reg u128[8] st;
     st = init(key_p, nonce_p);
@@ -337,11 +339,12 @@ export fn _aegis128l_decrypt(#public reg u64 params)
     full_blocks = ad_len_;
     full_blocks = full_blocks & -32;
 
-    reg u64 i = #set0();
+    reg u64 i;
+    ?{}, i = #set0();
     #align while (i < full_blocks) {
         reg u128[2] t;
-        t[0] = (u128)[ad_p + i];
-        t[1] = (u128)[ad_p + i + 16];
+        t[0] = [:u128 ad_p + i];
+        t[1] = [:u128 ad_p + i + 16];
         st = absorb(st, t);
         i += 32;
     }
@@ -357,9 +360,9 @@ export fn _aegis128l_decrypt(#public reg u64 params)
         pad[0] = zero;
         pad[1] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[ad_p + i];
+            pad[:u8 i] = [:u8 ad_p + i];
             i += 1;
         }
 
@@ -375,15 +378,15 @@ export fn _aegis128l_decrypt(#public reg u64 params)
     full_blocks = ct_len_;
     full_blocks = full_blocks & -32;
 
-    i = #set0();
+    ?{}, i = #set0();
     #align while (i < full_blocks) {
         #public reg u128[2] t;
-        #declassify t[0] = (u128)[ct_p + i];
-        #declassify t[1] = (u128)[ct_p + i + 16];
+        #declassify t[0] = [:u128 ct_p + i];
+        #declassify t[1] = [:u128 ct_p + i + 16];
         #secret reg u128[2] out;
         st, out = dec(st, t);
-        (u128)[msg_p + i] = out[0];
-        (u128)[msg_p + i + 16] = out[1];
+        [:u128 msg_p + i] = out[0];
+        [:u128 msg_p + i + 16] = out[1];
         i += 32;
     }
 
@@ -398,9 +401,9 @@ export fn _aegis128l_decrypt(#public reg u64 params)
         pad[0] = zero;
         pad[1] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[ct_p + i];
+            pad[:u8 i] = [:u8 ct_p + i];
             i += 1;
         }
 
@@ -413,9 +416,9 @@ export fn _aegis128l_decrypt(#public reg u64 params)
         pad[0] = out[0];
         pad[1] = out[1];
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            (u8)[msg_p + i] = pad[u8(int) i];
+            [:u8 msg_p + i] = pad[:u8 i];
             i += 1;
         }
     }

--- a/src/aegis128l/aegis128l.s
+++ b/src/aegis128l/aegis128l.s
@@ -1,10 +1,10 @@
 	.att_syntax
 	.text
 	.p2align	5
-	.globl	__aegis128l_decrypt
-	.globl	_aegis128l_decrypt
-	.globl	__aegis128l_encrypt
-	.globl	_aegis128l_encrypt
+	.global	__aegis128l_decrypt
+	.global	_aegis128l_decrypt
+	.global	__aegis128l_encrypt
+	.global	_aegis128l_encrypt
 __aegis128l_decrypt:
 _aegis128l_decrypt:
 	movq	%rsp, %r11
@@ -132,35 +132,35 @@ _aegis128l_decrypt:
 	vaesenc	%xmm7, %xmm8, %xmm7
 	vaesenc	%xmm11, %xmm9, %xmm8
 	vmovdqu	%xmm10, %xmm9
-	vpxor	%xmm0, %xmm4, %xmm11
-	vaesenc	%xmm10, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm3, %xmm2
-	vaesenc	%xmm3, %xmm4, %xmm3
-	vaesenc	%xmm11, %xmm5, %xmm4
-	vpxor	%xmm1, %xmm8, %xmm10
-	vaesenc	%xmm5, %xmm6, %xmm1
-	vaesenc	%xmm6, %xmm7, %xmm5
-	vaesenc	%xmm7, %xmm8, %xmm6
-	vaesenc	%xmm10, %xmm9, %xmm9
+	vpxor	%xmm0, %xmm4, %xmm0
+	vaesenc	%xmm10, %xmm2, %xmm11
+	vaesenc	%xmm2, %xmm3, %xmm10
+	vaesenc	%xmm3, %xmm4, %xmm2
+	vaesenc	%xmm0, %xmm5, %xmm0
+	vpxor	%xmm1, %xmm8, %xmm12
+	vaesenc	%xmm5, %xmm6, %xmm4
+	vaesenc	%xmm6, %xmm7, %xmm3
+	vaesenc	%xmm7, %xmm8, %xmm1
+	vaesenc	%xmm12, %xmm9, %xmm9
 	movq	88(%rsp), %rdi
 	andq	$-32, %rdi
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis128l_decrypt$15
 	.p2align	5
 L_aegis128l_decrypt$16:
-	vmovdqu	(%r8,%r9), %xmm7
-	vmovdqu	16(%r8,%r9), %xmm8
-	vmovdqu	%xmm0, %xmm10
-	vpxor	%xmm8, %xmm4, %xmm8
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm3, %xmm2
-	vaesenc	%xmm3, %xmm4, %xmm3
-	vaesenc	%xmm8, %xmm1, %xmm4
-	vpxor	%xmm7, %xmm9, %xmm7
-	vaesenc	%xmm1, %xmm5, %xmm1
-	vaesenc	%xmm5, %xmm6, %xmm5
-	vaesenc	%xmm6, %xmm9, %xmm6
-	vaesenc	%xmm7, %xmm10, %xmm9
+	vmovdqu	(%r8,%r9), %xmm5
+	vmovdqu	16(%r8,%r9), %xmm6
+	vmovdqu	%xmm11, %xmm7
+	vpxor	%xmm6, %xmm0, %xmm6
+	vaesenc	%xmm11, %xmm10, %xmm11
+	vaesenc	%xmm10, %xmm2, %xmm10
+	vaesenc	%xmm2, %xmm0, %xmm2
+	vaesenc	%xmm6, %xmm4, %xmm0
+	vpxor	%xmm5, %xmm9, %xmm5
+	vaesenc	%xmm4, %xmm3, %xmm4
+	vaesenc	%xmm3, %xmm1, %xmm3
+	vaesenc	%xmm1, %xmm9, %xmm1
+	vaesenc	%xmm5, %xmm7, %xmm9
 	addq	$32, %r9
 L_aegis128l_decrypt$15:
 	cmpq	%rdi, %r9
@@ -170,10 +170,10 @@ L_aegis128l_decrypt$15:
 	cmpq	$0, %rdi
 	jbe 	L_aegis128l_decrypt$12
 	addq	%r9, %r8
-	vpxor	%xmm7, %xmm7, %xmm7
-	vmovdqu	%xmm7, 16(%rsp)
-	vmovdqu	%xmm7, 32(%rsp)
-	xorq	%r9, %r9
+	vpxor	%xmm5, %xmm5, %xmm5
+	vmovdqu	%xmm5, 16(%rsp)
+	vmovdqu	%xmm5, 32(%rsp)
+	xorl	%r9d, %r9d
 	jmp 	L_aegis128l_decrypt$13
 L_aegis128l_decrypt$14:
 	movb	(%r8,%r9), %r10b
@@ -182,49 +182,49 @@ L_aegis128l_decrypt$14:
 L_aegis128l_decrypt$13:
 	cmpq	%rdi, %r9
 	jb  	L_aegis128l_decrypt$14
-	vmovdqu	16(%rsp), %xmm7
-	vmovdqu	32(%rsp), %xmm8
-	vmovdqu	%xmm0, %xmm10
-	vpxor	%xmm8, %xmm4, %xmm8
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm3, %xmm2
-	vaesenc	%xmm3, %xmm4, %xmm3
-	vaesenc	%xmm8, %xmm1, %xmm4
-	vpxor	%xmm7, %xmm9, %xmm7
-	vaesenc	%xmm1, %xmm5, %xmm1
-	vaesenc	%xmm5, %xmm6, %xmm5
-	vaesenc	%xmm6, %xmm9, %xmm6
-	vaesenc	%xmm7, %xmm10, %xmm9
+	vmovdqu	16(%rsp), %xmm5
+	vmovdqu	32(%rsp), %xmm6
+	vmovdqu	%xmm11, %xmm7
+	vpxor	%xmm6, %xmm0, %xmm6
+	vaesenc	%xmm11, %xmm10, %xmm11
+	vaesenc	%xmm10, %xmm2, %xmm10
+	vaesenc	%xmm2, %xmm0, %xmm2
+	vaesenc	%xmm6, %xmm4, %xmm0
+	vpxor	%xmm5, %xmm9, %xmm5
+	vaesenc	%xmm4, %xmm3, %xmm4
+	vaesenc	%xmm3, %xmm1, %xmm3
+	vaesenc	%xmm1, %xmm9, %xmm1
+	vaesenc	%xmm5, %xmm7, %xmm9
 L_aegis128l_decrypt$12:
 	movq	80(%rsp), %rdi
 	andq	$-32, %rdi
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis128l_decrypt$10
 	.p2align	5
 L_aegis128l_decrypt$11:
-	vmovdqu	(%rax,%r8), %xmm8
-	vmovdqu	16(%rax,%r8), %xmm7
-	vpand	%xmm1, %xmm5, %xmm10
-	vpand	%xmm0, %xmm2, %xmm11
-	vpxor	%xmm6, %xmm2, %xmm12
-	vpxor	%xmm3, %xmm5, %xmm13
-	vpxor	%xmm10, %xmm12, %xmm10
-	vpxor	%xmm11, %xmm13, %xmm11
-	vpxor	%xmm10, %xmm8, %xmm8
-	vpxor	%xmm11, %xmm7, %xmm7
-	vmovdqu	%xmm0, %xmm10
-	vpxor	%xmm7, %xmm4, %xmm11
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm3, %xmm2
-	vaesenc	%xmm3, %xmm4, %xmm3
-	vaesenc	%xmm11, %xmm1, %xmm4
-	vpxor	%xmm8, %xmm9, %xmm11
-	vaesenc	%xmm1, %xmm5, %xmm1
-	vaesenc	%xmm5, %xmm6, %xmm5
-	vaesenc	%xmm6, %xmm9, %xmm6
-	vaesenc	%xmm11, %xmm10, %xmm9
-	vmovdqu	%xmm8, (%rsi,%r8)
-	vmovdqu	%xmm7, 16(%rsi,%r8)
+	vmovdqu	(%rax,%r8), %xmm6
+	vmovdqu	16(%rax,%r8), %xmm5
+	vpand	%xmm4, %xmm3, %xmm7
+	vpand	%xmm11, %xmm10, %xmm8
+	vpxor	%xmm1, %xmm10, %xmm12
+	vpxor	%xmm2, %xmm3, %xmm13
+	vpxor	%xmm7, %xmm12, %xmm7
+	vpxor	%xmm8, %xmm13, %xmm8
+	vpxor	%xmm7, %xmm6, %xmm6
+	vpxor	%xmm8, %xmm5, %xmm5
+	vmovdqu	%xmm11, %xmm7
+	vpxor	%xmm5, %xmm0, %xmm8
+	vaesenc	%xmm11, %xmm10, %xmm11
+	vaesenc	%xmm10, %xmm2, %xmm10
+	vaesenc	%xmm2, %xmm0, %xmm2
+	vaesenc	%xmm8, %xmm4, %xmm0
+	vpxor	%xmm6, %xmm9, %xmm8
+	vaesenc	%xmm4, %xmm3, %xmm4
+	vaesenc	%xmm3, %xmm1, %xmm3
+	vaesenc	%xmm1, %xmm9, %xmm1
+	vaesenc	%xmm8, %xmm7, %xmm9
+	vmovdqu	%xmm6, (%rsi,%r8)
+	vmovdqu	%xmm5, 16(%rsi,%r8)
 	addq	$32, %r8
 L_aegis128l_decrypt$10:
 	cmpq	%rdi, %r8
@@ -235,10 +235,10 @@ L_aegis128l_decrypt$10:
 	jbe 	L_aegis128l_decrypt$3
 	addq	%r8, %rsi
 	addq	%r8, %rax
-	vpxor	%xmm7, %xmm7, %xmm7
-	vmovdqu	%xmm7, 16(%rsp)
-	vmovdqu	%xmm7, 32(%rsp)
-	xorq	%r8, %r8
+	vpxor	%xmm5, %xmm5, %xmm5
+	vmovdqu	%xmm5, 16(%rsp)
+	vmovdqu	%xmm5, 32(%rsp)
+	xorl	%r8d, %r8d
 	jmp 	L_aegis128l_decrypt$8
 L_aegis128l_decrypt$9:
 	movb	(%rax,%r8), %r9b
@@ -247,18 +247,18 @@ L_aegis128l_decrypt$9:
 L_aegis128l_decrypt$8:
 	cmpq	%rdi, %r8
 	jb  	L_aegis128l_decrypt$9
-	vmovdqu	16(%rsp), %xmm8
-	vmovdqu	32(%rsp), %xmm7
-	vpand	%xmm1, %xmm5, %xmm10
-	vpand	%xmm0, %xmm2, %xmm11
-	vpxor	%xmm6, %xmm2, %xmm12
-	vpxor	%xmm3, %xmm5, %xmm13
-	vpxor	%xmm10, %xmm12, %xmm10
-	vpxor	%xmm11, %xmm13, %xmm11
-	vpxor	%xmm10, %xmm8, %xmm8
-	vpxor	%xmm11, %xmm7, %xmm7
-	vmovdqu	%xmm8, 48(%rsp)
-	vmovdqu	%xmm7, 64(%rsp)
+	vmovdqu	16(%rsp), %xmm6
+	vmovdqu	32(%rsp), %xmm5
+	vpand	%xmm4, %xmm3, %xmm7
+	vpand	%xmm11, %xmm10, %xmm8
+	vpxor	%xmm1, %xmm10, %xmm12
+	vpxor	%xmm2, %xmm3, %xmm13
+	vpxor	%xmm7, %xmm12, %xmm7
+	vpxor	%xmm8, %xmm13, %xmm8
+	vpxor	%xmm7, %xmm6, %xmm6
+	vpxor	%xmm8, %xmm5, %xmm5
+	vmovdqu	%xmm6, 48(%rsp)
+	vmovdqu	%xmm5, 64(%rsp)
 	movq	%rdi, %rax
 	jmp 	L_aegis128l_decrypt$6
 L_aegis128l_decrypt$7:
@@ -267,22 +267,22 @@ L_aegis128l_decrypt$7:
 L_aegis128l_decrypt$6:
 	cmpq	$32, %rax
 	jb  	L_aegis128l_decrypt$7
-	vmovdqu	48(%rsp), %xmm10
-	vmovdqu	64(%rsp), %xmm11
-	vmovdqu	%xmm0, %xmm12
-	vpxor	%xmm11, %xmm4, %xmm11
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm3, %xmm2
-	vaesenc	%xmm3, %xmm4, %xmm3
-	vaesenc	%xmm11, %xmm1, %xmm4
-	vpxor	%xmm10, %xmm9, %xmm10
-	vaesenc	%xmm1, %xmm5, %xmm1
-	vaesenc	%xmm5, %xmm6, %xmm5
-	vaesenc	%xmm6, %xmm9, %xmm6
-	vaesenc	%xmm10, %xmm12, %xmm9
-	vmovdqu	%xmm8, 16(%rsp)
-	vmovdqu	%xmm7, 32(%rsp)
-	xorq	%rax, %rax
+	vmovdqu	48(%rsp), %xmm7
+	vmovdqu	64(%rsp), %xmm8
+	vmovdqu	%xmm11, %xmm12
+	vpxor	%xmm8, %xmm0, %xmm8
+	vaesenc	%xmm11, %xmm10, %xmm11
+	vaesenc	%xmm10, %xmm2, %xmm10
+	vaesenc	%xmm2, %xmm0, %xmm2
+	vaesenc	%xmm8, %xmm4, %xmm0
+	vpxor	%xmm7, %xmm9, %xmm7
+	vaesenc	%xmm4, %xmm3, %xmm4
+	vaesenc	%xmm3, %xmm1, %xmm3
+	vaesenc	%xmm1, %xmm9, %xmm1
+	vaesenc	%xmm7, %xmm12, %xmm9
+	vmovdqu	%xmm6, 16(%rsp)
+	vmovdqu	%xmm5, 32(%rsp)
+	xorl	%eax, %eax
 	jmp 	L_aegis128l_decrypt$4
 L_aegis128l_decrypt$5:
 	movb	16(%rsp,%rax), %r8b
@@ -294,120 +294,119 @@ L_aegis128l_decrypt$4:
 L_aegis128l_decrypt$3:
 	movq	88(%rsp), %rax
 	movq	80(%rsp), %rsi
-	xorq	%rdi, %rdi
 	shlq	$3, %rax
 	shlq	$3, %rsi
 	movq	%rax, (%rsp)
 	movq	%rsi, 8(%rsp)
-	vpxor	(%rsp), %xmm5, %xmm7
-	vmovdqu	%xmm0, %xmm8
-	vpxor	%xmm7, %xmm4, %xmm10
+	vpxor	(%rsp), %xmm3, %xmm5
+	vmovdqu	%xmm11, %xmm6
+	vpxor	%xmm5, %xmm0, %xmm12
+	vaesenc	%xmm11, %xmm10, %xmm7
+	vaesenc	%xmm10, %xmm2, %xmm8
+	vaesenc	%xmm2, %xmm0, %xmm10
+	vaesenc	%xmm12, %xmm4, %xmm11
+	vpxor	%xmm5, %xmm9, %xmm12
+	vaesenc	%xmm4, %xmm3, %xmm0
+	vaesenc	%xmm3, %xmm1, %xmm2
+	vaesenc	%xmm1, %xmm9, %xmm1
+	vaesenc	%xmm12, %xmm6, %xmm9
+	vmovdqu	%xmm7, %xmm3
+	vpxor	%xmm5, %xmm11, %xmm12
+	vaesenc	%xmm7, %xmm8, %xmm4
+	vaesenc	%xmm8, %xmm10, %xmm6
+	vaesenc	%xmm10, %xmm11, %xmm7
+	vaesenc	%xmm12, %xmm0, %xmm8
+	vpxor	%xmm5, %xmm9, %xmm10
 	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm3, %xmm2
-	vaesenc	%xmm3, %xmm4, %xmm4
-	vaesenc	%xmm10, %xmm1, %xmm10
-	vpxor	%xmm7, %xmm9, %xmm11
-	vaesenc	%xmm1, %xmm5, %xmm1
-	vaesenc	%xmm5, %xmm6, %xmm3
-	vaesenc	%xmm6, %xmm9, %xmm5
-	vaesenc	%xmm11, %xmm8, %xmm9
-	vmovdqu	%xmm0, %xmm6
-	vpxor	%xmm7, %xmm10, %xmm8
+	vaesenc	%xmm2, %xmm1, %xmm2
+	vaesenc	%xmm1, %xmm9, %xmm1
+	vaesenc	%xmm10, %xmm3, %xmm9
+	vmovdqu	%xmm4, %xmm3
+	vpxor	%xmm5, %xmm8, %xmm10
+	vaesenc	%xmm4, %xmm6, %xmm4
+	vaesenc	%xmm6, %xmm7, %xmm6
+	vaesenc	%xmm7, %xmm8, %xmm7
+	vaesenc	%xmm10, %xmm0, %xmm8
+	vpxor	%xmm5, %xmm9, %xmm10
 	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm4, %xmm2
-	vaesenc	%xmm4, %xmm10, %xmm4
-	vaesenc	%xmm8, %xmm1, %xmm8
-	vpxor	%xmm7, %xmm9, %xmm10
+	vaesenc	%xmm2, %xmm1, %xmm2
+	vaesenc	%xmm1, %xmm9, %xmm1
+	vaesenc	%xmm10, %xmm3, %xmm9
+	vmovdqu	%xmm4, %xmm3
+	vpxor	%xmm5, %xmm8, %xmm10
+	vaesenc	%xmm4, %xmm6, %xmm4
+	vaesenc	%xmm6, %xmm7, %xmm6
+	vaesenc	%xmm7, %xmm8, %xmm7
+	vaesenc	%xmm10, %xmm0, %xmm8
+	vpxor	%xmm5, %xmm9, %xmm10
+	vaesenc	%xmm0, %xmm2, %xmm0
+	vaesenc	%xmm2, %xmm1, %xmm2
+	vaesenc	%xmm1, %xmm9, %xmm1
+	vaesenc	%xmm10, %xmm3, %xmm9
+	vmovdqu	%xmm4, %xmm3
+	vpxor	%xmm5, %xmm8, %xmm10
+	vaesenc	%xmm4, %xmm6, %xmm4
+	vaesenc	%xmm6, %xmm7, %xmm6
+	vaesenc	%xmm7, %xmm8, %xmm7
+	vaesenc	%xmm10, %xmm0, %xmm8
+	vpxor	%xmm5, %xmm9, %xmm10
+	vaesenc	%xmm0, %xmm2, %xmm0
+	vaesenc	%xmm2, %xmm1, %xmm2
+	vaesenc	%xmm1, %xmm9, %xmm1
+	vaesenc	%xmm10, %xmm3, %xmm9
+	vmovdqu	%xmm4, %xmm3
+	vpxor	%xmm5, %xmm8, %xmm10
+	vaesenc	%xmm4, %xmm6, %xmm4
+	vaesenc	%xmm6, %xmm7, %xmm6
+	vaesenc	%xmm7, %xmm8, %xmm7
+	vaesenc	%xmm10, %xmm0, %xmm8
+	vpxor	%xmm5, %xmm9, %xmm10
+	vaesenc	%xmm0, %xmm2, %xmm0
+	vaesenc	%xmm2, %xmm1, %xmm2
+	vaesenc	%xmm1, %xmm9, %xmm1
+	vaesenc	%xmm10, %xmm3, %xmm3
+	vmovdqu	%xmm4, %xmm9
+	vpxor	%xmm5, %xmm8, %xmm10
+	vaesenc	%xmm4, %xmm6, %xmm4
+	vaesenc	%xmm6, %xmm7, %xmm6
+	vaesenc	%xmm7, %xmm8, %xmm7
+	vaesenc	%xmm10, %xmm0, %xmm8
+	vpxor	%xmm5, %xmm3, %xmm5
+	vaesenc	%xmm0, %xmm2, %xmm0
+	vaesenc	%xmm2, %xmm1, %xmm2
 	vaesenc	%xmm1, %xmm3, %xmm1
-	vaesenc	%xmm3, %xmm5, %xmm3
-	vaesenc	%xmm5, %xmm9, %xmm5
-	vaesenc	%xmm10, %xmm6, %xmm9
-	vmovdqu	%xmm0, %xmm6
-	vpxor	%xmm7, %xmm8, %xmm10
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm4, %xmm2
-	vaesenc	%xmm4, %xmm8, %xmm4
-	vaesenc	%xmm10, %xmm1, %xmm8
-	vpxor	%xmm7, %xmm9, %xmm10
-	vaesenc	%xmm1, %xmm3, %xmm1
-	vaesenc	%xmm3, %xmm5, %xmm3
-	vaesenc	%xmm5, %xmm9, %xmm5
-	vaesenc	%xmm10, %xmm6, %xmm9
-	vmovdqu	%xmm0, %xmm6
-	vpxor	%xmm7, %xmm8, %xmm10
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm4, %xmm2
-	vaesenc	%xmm4, %xmm8, %xmm4
-	vaesenc	%xmm10, %xmm1, %xmm8
-	vpxor	%xmm7, %xmm9, %xmm10
-	vaesenc	%xmm1, %xmm3, %xmm1
-	vaesenc	%xmm3, %xmm5, %xmm3
-	vaesenc	%xmm5, %xmm9, %xmm5
-	vaesenc	%xmm10, %xmm6, %xmm9
-	vmovdqu	%xmm0, %xmm6
-	vpxor	%xmm7, %xmm8, %xmm10
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm4, %xmm2
-	vaesenc	%xmm4, %xmm8, %xmm4
-	vaesenc	%xmm10, %xmm1, %xmm8
-	vpxor	%xmm7, %xmm9, %xmm10
-	vaesenc	%xmm1, %xmm3, %xmm1
-	vaesenc	%xmm3, %xmm5, %xmm3
-	vaesenc	%xmm5, %xmm9, %xmm5
-	vaesenc	%xmm10, %xmm6, %xmm9
-	vmovdqu	%xmm0, %xmm6
-	vpxor	%xmm7, %xmm8, %xmm10
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm4, %xmm2
-	vaesenc	%xmm4, %xmm8, %xmm4
-	vaesenc	%xmm10, %xmm1, %xmm8
-	vpxor	%xmm7, %xmm9, %xmm10
-	vaesenc	%xmm1, %xmm3, %xmm1
-	vaesenc	%xmm3, %xmm5, %xmm3
-	vaesenc	%xmm5, %xmm9, %xmm5
-	vaesenc	%xmm10, %xmm6, %xmm6
-	vmovdqu	%xmm0, %xmm9
-	vpxor	%xmm7, %xmm8, %xmm10
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm4, %xmm2
-	vaesenc	%xmm4, %xmm8, %xmm4
-	vaesenc	%xmm10, %xmm1, %xmm8
-	vpxor	%xmm7, %xmm6, %xmm7
-	vaesenc	%xmm1, %xmm3, %xmm1
-	vaesenc	%xmm3, %xmm5, %xmm3
-	vaesenc	%xmm5, %xmm6, %xmm5
-	vaesenc	%xmm7, %xmm9, %xmm6
+	vaesenc	%xmm5, %xmm9, %xmm3
 	cmpb	$16, %dl
 	je  	L_aegis128l_decrypt$1
-	vpxor	%xmm5, %xmm6, %xmm5
-	vpxor	%xmm4, %xmm8, %xmm4
-	vpxor	%xmm3, %xmm5, %xmm3
-	vpxor	%xmm2, %xmm4, %xmm2
 	vpxor	%xmm1, %xmm3, %xmm1
-	vpxor	%xmm0, %xmm2, %xmm0
+	vpxor	%xmm7, %xmm8, %xmm3
+	vpxor	%xmm2, %xmm1, %xmm1
+	vpxor	%xmm6, %xmm3, %xmm2
+	vpxor	%xmm0, %xmm1, %xmm0
+	vpxor	%xmm4, %xmm2, %xmm1
 	vmovdqu	(%rcx), %xmm2
 	vmovdqu	16(%rcx), %xmm3
-	vpcmpeqq	%xmm1, %xmm2, %xmm1
-	vpcmpeqq	%xmm0, %xmm3, %xmm0
-	vpand	%xmm0, %xmm1, %xmm0
-	vpmovmskb	%xmm0, %rax
+	vpcmpeqq	%xmm0, %xmm2, %xmm0
+	vpcmpeqq	%xmm1, %xmm3, %xmm1
+	vpand	%xmm1, %xmm0, %xmm0
+	vpmovmskb	%xmm0, %eax
 	incq	%rax
 	shrq	$16, %rax
-	addq	$-1, %rax
+	decq	%rax
 	jmp 	L_aegis128l_decrypt$2
 L_aegis128l_decrypt$1:
-	vpxor	%xmm5, %xmm6, %xmm0
-	vpxor	%xmm3, %xmm0, %xmm0
-	vpxor	%xmm1, %xmm0, %xmm0
+	vpxor	%xmm1, %xmm3, %xmm1
+	vpxor	%xmm2, %xmm1, %xmm1
+	vpxor	%xmm0, %xmm1, %xmm0
 	vpxor	%xmm8, %xmm0, %xmm0
-	vpxor	%xmm4, %xmm0, %xmm0
-	vpxor	%xmm2, %xmm0, %xmm0
+	vpxor	%xmm7, %xmm0, %xmm0
+	vpxor	%xmm6, %xmm0, %xmm0
 	vmovdqu	(%rcx), %xmm1
 	vpcmpeqq	%xmm0, %xmm1, %xmm0
-	vpmovmskb	%xmm0, %rax
+	vpmovmskb	%xmm0, %eax
 	incq	%rax
 	shrq	$16, %rax
-	addq	$-1, %rax
+	decq	%rax
 L_aegis128l_decrypt$2:
 	movq	%r11, %rsp
 	movq	%rsp, %rsi
@@ -549,35 +548,35 @@ _aegis128l_encrypt:
 	vaesenc	%xmm7, %xmm8, %xmm7
 	vaesenc	%xmm11, %xmm9, %xmm8
 	vmovdqu	%xmm10, %xmm9
-	vpxor	%xmm0, %xmm4, %xmm11
-	vaesenc	%xmm10, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm3, %xmm2
-	vaesenc	%xmm3, %xmm4, %xmm3
-	vaesenc	%xmm11, %xmm5, %xmm4
-	vpxor	%xmm1, %xmm8, %xmm10
-	vaesenc	%xmm5, %xmm6, %xmm1
-	vaesenc	%xmm6, %xmm7, %xmm5
-	vaesenc	%xmm7, %xmm8, %xmm6
-	vaesenc	%xmm10, %xmm9, %xmm9
+	vpxor	%xmm0, %xmm4, %xmm0
+	vaesenc	%xmm10, %xmm2, %xmm11
+	vaesenc	%xmm2, %xmm3, %xmm10
+	vaesenc	%xmm3, %xmm4, %xmm2
+	vaesenc	%xmm0, %xmm5, %xmm0
+	vpxor	%xmm1, %xmm8, %xmm12
+	vaesenc	%xmm5, %xmm6, %xmm4
+	vaesenc	%xmm6, %xmm7, %xmm1
+	vaesenc	%xmm7, %xmm8, %xmm3
+	vaesenc	%xmm12, %xmm9, %xmm9
 	movq	56(%rsp), %rdi
 	andq	$-32, %rdi
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis128l_encrypt$13
 	.p2align	5
 L_aegis128l_encrypt$14:
-	vmovdqu	(%r8,%r9), %xmm7
-	vmovdqu	16(%r8,%r9), %xmm8
-	vmovdqu	%xmm0, %xmm10
-	vpxor	%xmm8, %xmm4, %xmm8
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm3, %xmm2
-	vaesenc	%xmm3, %xmm4, %xmm3
-	vaesenc	%xmm8, %xmm1, %xmm4
-	vpxor	%xmm7, %xmm9, %xmm7
-	vaesenc	%xmm1, %xmm5, %xmm1
-	vaesenc	%xmm5, %xmm6, %xmm5
-	vaesenc	%xmm6, %xmm9, %xmm6
-	vaesenc	%xmm7, %xmm10, %xmm9
+	vmovdqu	(%r8,%r9), %xmm5
+	vmovdqu	16(%r8,%r9), %xmm6
+	vmovdqu	%xmm11, %xmm7
+	vpxor	%xmm6, %xmm0, %xmm6
+	vaesenc	%xmm11, %xmm10, %xmm11
+	vaesenc	%xmm10, %xmm2, %xmm10
+	vaesenc	%xmm2, %xmm0, %xmm2
+	vaesenc	%xmm6, %xmm4, %xmm0
+	vpxor	%xmm5, %xmm9, %xmm5
+	vaesenc	%xmm4, %xmm1, %xmm4
+	vaesenc	%xmm1, %xmm3, %xmm1
+	vaesenc	%xmm3, %xmm9, %xmm3
+	vaesenc	%xmm5, %xmm7, %xmm9
 	addq	$32, %r9
 L_aegis128l_encrypt$13:
 	cmpq	%rdi, %r9
@@ -587,10 +586,10 @@ L_aegis128l_encrypt$13:
 	cmpq	$0, %rdi
 	jbe 	L_aegis128l_encrypt$10
 	addq	%r9, %r8
-	vpxor	%xmm7, %xmm7, %xmm7
-	vmovdqu	%xmm7, 16(%rsp)
-	vmovdqu	%xmm7, 32(%rsp)
-	xorq	%r9, %r9
+	vpxor	%xmm5, %xmm5, %xmm5
+	vmovdqu	%xmm5, 16(%rsp)
+	vmovdqu	%xmm5, 32(%rsp)
+	xorl	%r9d, %r9d
 	jmp 	L_aegis128l_encrypt$11
 L_aegis128l_encrypt$12:
 	movb	(%r8,%r9), %r10b
@@ -599,49 +598,49 @@ L_aegis128l_encrypt$12:
 L_aegis128l_encrypt$11:
 	cmpq	%rdi, %r9
 	jb  	L_aegis128l_encrypt$12
-	vmovdqu	16(%rsp), %xmm7
-	vmovdqu	32(%rsp), %xmm8
-	vmovdqu	%xmm0, %xmm10
-	vpxor	%xmm8, %xmm4, %xmm8
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm3, %xmm2
-	vaesenc	%xmm3, %xmm4, %xmm3
-	vaesenc	%xmm8, %xmm1, %xmm4
-	vpxor	%xmm7, %xmm9, %xmm7
-	vaesenc	%xmm1, %xmm5, %xmm1
-	vaesenc	%xmm5, %xmm6, %xmm5
-	vaesenc	%xmm6, %xmm9, %xmm6
-	vaesenc	%xmm7, %xmm10, %xmm9
+	vmovdqu	16(%rsp), %xmm5
+	vmovdqu	32(%rsp), %xmm6
+	vmovdqu	%xmm11, %xmm7
+	vpxor	%xmm6, %xmm0, %xmm6
+	vaesenc	%xmm11, %xmm10, %xmm11
+	vaesenc	%xmm10, %xmm2, %xmm10
+	vaesenc	%xmm2, %xmm0, %xmm2
+	vaesenc	%xmm6, %xmm4, %xmm0
+	vpxor	%xmm5, %xmm9, %xmm5
+	vaesenc	%xmm4, %xmm1, %xmm4
+	vaesenc	%xmm1, %xmm3, %xmm1
+	vaesenc	%xmm3, %xmm9, %xmm3
+	vaesenc	%xmm5, %xmm7, %xmm9
 L_aegis128l_encrypt$10:
 	movq	48(%rsp), %rdi
 	andq	$-32, %rdi
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis128l_encrypt$8
 	.p2align	5
 L_aegis128l_encrypt$9:
-	vmovdqu	(%rsi,%r8), %xmm7
-	vmovdqu	16(%rsi,%r8), %xmm8
-	vpand	%xmm1, %xmm5, %xmm10
-	vpand	%xmm0, %xmm2, %xmm11
-	vpxor	%xmm6, %xmm2, %xmm12
-	vpxor	%xmm3, %xmm5, %xmm13
-	vpxor	%xmm10, %xmm12, %xmm10
-	vpxor	%xmm11, %xmm13, %xmm11
-	vpxor	%xmm10, %xmm7, %xmm10
-	vpxor	%xmm11, %xmm8, %xmm11
-	vmovdqu	%xmm0, %xmm12
-	vpxor	%xmm8, %xmm4, %xmm8
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm3, %xmm2
-	vaesenc	%xmm3, %xmm4, %xmm3
-	vaesenc	%xmm8, %xmm1, %xmm4
-	vpxor	%xmm7, %xmm9, %xmm7
-	vaesenc	%xmm1, %xmm5, %xmm1
-	vaesenc	%xmm5, %xmm6, %xmm5
-	vaesenc	%xmm6, %xmm9, %xmm6
-	vaesenc	%xmm7, %xmm12, %xmm9
-	vmovdqu	%xmm10, (%rax,%r8)
-	vmovdqu	%xmm11, 16(%rax,%r8)
+	vmovdqu	(%rsi,%r8), %xmm5
+	vmovdqu	16(%rsi,%r8), %xmm6
+	vpand	%xmm4, %xmm1, %xmm7
+	vpand	%xmm11, %xmm10, %xmm8
+	vpxor	%xmm3, %xmm10, %xmm12
+	vpxor	%xmm2, %xmm1, %xmm13
+	vpxor	%xmm7, %xmm12, %xmm7
+	vpxor	%xmm8, %xmm13, %xmm8
+	vpxor	%xmm7, %xmm5, %xmm7
+	vpxor	%xmm8, %xmm6, %xmm8
+	vmovdqu	%xmm11, %xmm12
+	vpxor	%xmm6, %xmm0, %xmm6
+	vaesenc	%xmm11, %xmm10, %xmm11
+	vaesenc	%xmm10, %xmm2, %xmm10
+	vaesenc	%xmm2, %xmm0, %xmm2
+	vaesenc	%xmm6, %xmm4, %xmm0
+	vpxor	%xmm5, %xmm9, %xmm5
+	vaesenc	%xmm4, %xmm1, %xmm4
+	vaesenc	%xmm1, %xmm3, %xmm1
+	vaesenc	%xmm3, %xmm9, %xmm3
+	vaesenc	%xmm5, %xmm12, %xmm9
+	vmovdqu	%xmm7, (%rax,%r8)
+	vmovdqu	%xmm8, 16(%rax,%r8)
 	addq	$32, %r8
 L_aegis128l_encrypt$8:
 	cmpq	%rdi, %r8
@@ -652,10 +651,10 @@ L_aegis128l_encrypt$8:
 	jbe 	L_aegis128l_encrypt$3
 	addq	%r8, %rsi
 	addq	%r8, %rax
-	vpxor	%xmm7, %xmm7, %xmm7
-	vmovdqu	%xmm7, 16(%rsp)
-	vmovdqu	%xmm7, 32(%rsp)
-	xorq	%r8, %r8
+	vpxor	%xmm5, %xmm5, %xmm5
+	vmovdqu	%xmm5, 16(%rsp)
+	vmovdqu	%xmm5, 32(%rsp)
+	xorl	%r8d, %r8d
 	jmp 	L_aegis128l_encrypt$6
 L_aegis128l_encrypt$7:
 	movb	(%rsi,%r8), %r9b
@@ -664,30 +663,30 @@ L_aegis128l_encrypt$7:
 L_aegis128l_encrypt$6:
 	cmpq	%rdi, %r8
 	jb  	L_aegis128l_encrypt$7
-	vmovdqu	16(%rsp), %xmm7
-	vmovdqu	32(%rsp), %xmm8
-	vpand	%xmm1, %xmm5, %xmm10
-	vpand	%xmm0, %xmm2, %xmm11
-	vpxor	%xmm6, %xmm2, %xmm12
-	vpxor	%xmm3, %xmm5, %xmm13
-	vpxor	%xmm10, %xmm12, %xmm10
-	vpxor	%xmm11, %xmm13, %xmm11
-	vpxor	%xmm10, %xmm7, %xmm10
-	vpxor	%xmm11, %xmm8, %xmm11
-	vmovdqu	%xmm0, %xmm12
-	vpxor	%xmm8, %xmm4, %xmm8
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm3, %xmm2
-	vaesenc	%xmm3, %xmm4, %xmm3
-	vaesenc	%xmm8, %xmm1, %xmm4
-	vpxor	%xmm7, %xmm9, %xmm7
-	vaesenc	%xmm1, %xmm5, %xmm1
-	vaesenc	%xmm5, %xmm6, %xmm5
-	vaesenc	%xmm6, %xmm9, %xmm6
-	vaesenc	%xmm7, %xmm12, %xmm9
-	vmovdqu	%xmm10, 16(%rsp)
-	vmovdqu	%xmm11, 32(%rsp)
-	xorq	%rsi, %rsi
+	vmovdqu	16(%rsp), %xmm5
+	vmovdqu	32(%rsp), %xmm6
+	vpand	%xmm4, %xmm1, %xmm7
+	vpand	%xmm11, %xmm10, %xmm8
+	vpxor	%xmm3, %xmm10, %xmm12
+	vpxor	%xmm2, %xmm1, %xmm13
+	vpxor	%xmm7, %xmm12, %xmm7
+	vpxor	%xmm8, %xmm13, %xmm8
+	vpxor	%xmm7, %xmm5, %xmm7
+	vpxor	%xmm8, %xmm6, %xmm8
+	vmovdqu	%xmm11, %xmm12
+	vpxor	%xmm6, %xmm0, %xmm6
+	vaesenc	%xmm11, %xmm10, %xmm11
+	vaesenc	%xmm10, %xmm2, %xmm10
+	vaesenc	%xmm2, %xmm0, %xmm2
+	vaesenc	%xmm6, %xmm4, %xmm0
+	vpxor	%xmm5, %xmm9, %xmm5
+	vaesenc	%xmm4, %xmm1, %xmm4
+	vaesenc	%xmm1, %xmm3, %xmm1
+	vaesenc	%xmm3, %xmm9, %xmm3
+	vaesenc	%xmm5, %xmm12, %xmm9
+	vmovdqu	%xmm7, 16(%rsp)
+	vmovdqu	%xmm8, 32(%rsp)
+	xorl	%esi, %esi
 	jmp 	L_aegis128l_encrypt$4
 L_aegis128l_encrypt$5:
 	movb	16(%rsp,%rsi), %r8b
@@ -699,107 +698,107 @@ L_aegis128l_encrypt$4:
 L_aegis128l_encrypt$3:
 	movq	56(%rsp), %rsi
 	movq	48(%rsp), %rdi
-	xorq	%rax, %rax
+	xorl	%eax, %eax
 	shlq	$3, %rsi
 	shlq	$3, %rdi
 	movq	%rsi, (%rsp)
 	movq	%rdi, 8(%rsp)
-	vpxor	(%rsp), %xmm5, %xmm7
-	vmovdqu	%xmm0, %xmm8
-	vpxor	%xmm7, %xmm4, %xmm10
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm3, %xmm2
-	vaesenc	%xmm3, %xmm4, %xmm4
-	vaesenc	%xmm10, %xmm1, %xmm10
-	vpxor	%xmm7, %xmm9, %xmm11
-	vaesenc	%xmm1, %xmm5, %xmm1
-	vaesenc	%xmm5, %xmm6, %xmm3
-	vaesenc	%xmm6, %xmm9, %xmm5
-	vaesenc	%xmm11, %xmm8, %xmm9
-	vmovdqu	%xmm0, %xmm6
-	vpxor	%xmm7, %xmm10, %xmm8
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm4, %xmm2
-	vaesenc	%xmm4, %xmm10, %xmm4
-	vaesenc	%xmm8, %xmm1, %xmm8
-	vpxor	%xmm7, %xmm9, %xmm10
+	vpxor	(%rsp), %xmm1, %xmm5
+	vmovdqu	%xmm11, %xmm6
+	vpxor	%xmm5, %xmm0, %xmm12
+	vaesenc	%xmm11, %xmm10, %xmm7
+	vaesenc	%xmm10, %xmm2, %xmm8
+	vaesenc	%xmm2, %xmm0, %xmm2
+	vaesenc	%xmm12, %xmm4, %xmm10
+	vpxor	%xmm5, %xmm9, %xmm11
+	vaesenc	%xmm4, %xmm1, %xmm0
 	vaesenc	%xmm1, %xmm3, %xmm1
-	vaesenc	%xmm3, %xmm5, %xmm3
-	vaesenc	%xmm5, %xmm9, %xmm5
-	vaesenc	%xmm10, %xmm6, %xmm9
-	vmovdqu	%xmm0, %xmm6
-	vpxor	%xmm7, %xmm8, %xmm10
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm4, %xmm2
-	vaesenc	%xmm4, %xmm8, %xmm4
-	vaesenc	%xmm10, %xmm1, %xmm8
-	vpxor	%xmm7, %xmm9, %xmm10
+	vaesenc	%xmm3, %xmm9, %xmm3
+	vaesenc	%xmm11, %xmm6, %xmm9
+	vmovdqu	%xmm7, %xmm4
+	vpxor	%xmm5, %xmm10, %xmm11
+	vaesenc	%xmm7, %xmm8, %xmm6
+	vaesenc	%xmm8, %xmm2, %xmm7
+	vaesenc	%xmm2, %xmm10, %xmm2
+	vaesenc	%xmm11, %xmm0, %xmm8
+	vpxor	%xmm5, %xmm9, %xmm10
+	vaesenc	%xmm0, %xmm1, %xmm0
 	vaesenc	%xmm1, %xmm3, %xmm1
-	vaesenc	%xmm3, %xmm5, %xmm3
-	vaesenc	%xmm5, %xmm9, %xmm5
-	vaesenc	%xmm10, %xmm6, %xmm9
-	vmovdqu	%xmm0, %xmm6
-	vpxor	%xmm7, %xmm8, %xmm10
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm4, %xmm2
-	vaesenc	%xmm4, %xmm8, %xmm4
-	vaesenc	%xmm10, %xmm1, %xmm8
-	vpxor	%xmm7, %xmm9, %xmm10
+	vaesenc	%xmm3, %xmm9, %xmm3
+	vaesenc	%xmm10, %xmm4, %xmm9
+	vmovdqu	%xmm6, %xmm4
+	vpxor	%xmm5, %xmm8, %xmm10
+	vaesenc	%xmm6, %xmm7, %xmm6
+	vaesenc	%xmm7, %xmm2, %xmm7
+	vaesenc	%xmm2, %xmm8, %xmm2
+	vaesenc	%xmm10, %xmm0, %xmm8
+	vpxor	%xmm5, %xmm9, %xmm10
+	vaesenc	%xmm0, %xmm1, %xmm0
 	vaesenc	%xmm1, %xmm3, %xmm1
-	vaesenc	%xmm3, %xmm5, %xmm3
-	vaesenc	%xmm5, %xmm9, %xmm5
-	vaesenc	%xmm10, %xmm6, %xmm9
-	vmovdqu	%xmm0, %xmm6
-	vpxor	%xmm7, %xmm8, %xmm10
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm4, %xmm2
-	vaesenc	%xmm4, %xmm8, %xmm4
-	vaesenc	%xmm10, %xmm1, %xmm8
-	vpxor	%xmm7, %xmm9, %xmm10
+	vaesenc	%xmm3, %xmm9, %xmm3
+	vaesenc	%xmm10, %xmm4, %xmm9
+	vmovdqu	%xmm6, %xmm4
+	vpxor	%xmm5, %xmm8, %xmm10
+	vaesenc	%xmm6, %xmm7, %xmm6
+	vaesenc	%xmm7, %xmm2, %xmm7
+	vaesenc	%xmm2, %xmm8, %xmm2
+	vaesenc	%xmm10, %xmm0, %xmm8
+	vpxor	%xmm5, %xmm9, %xmm10
+	vaesenc	%xmm0, %xmm1, %xmm0
 	vaesenc	%xmm1, %xmm3, %xmm1
-	vaesenc	%xmm3, %xmm5, %xmm3
-	vaesenc	%xmm5, %xmm9, %xmm5
-	vaesenc	%xmm10, %xmm6, %xmm9
-	vmovdqu	%xmm0, %xmm6
-	vpxor	%xmm7, %xmm8, %xmm10
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm4, %xmm2
-	vaesenc	%xmm4, %xmm8, %xmm4
-	vaesenc	%xmm10, %xmm1, %xmm8
-	vpxor	%xmm7, %xmm9, %xmm10
+	vaesenc	%xmm3, %xmm9, %xmm3
+	vaesenc	%xmm10, %xmm4, %xmm9
+	vmovdqu	%xmm6, %xmm4
+	vpxor	%xmm5, %xmm8, %xmm10
+	vaesenc	%xmm6, %xmm7, %xmm6
+	vaesenc	%xmm7, %xmm2, %xmm7
+	vaesenc	%xmm2, %xmm8, %xmm2
+	vaesenc	%xmm10, %xmm0, %xmm8
+	vpxor	%xmm5, %xmm9, %xmm10
+	vaesenc	%xmm0, %xmm1, %xmm0
 	vaesenc	%xmm1, %xmm3, %xmm1
-	vaesenc	%xmm3, %xmm5, %xmm3
-	vaesenc	%xmm5, %xmm9, %xmm5
-	vaesenc	%xmm10, %xmm6, %xmm6
-	vmovdqu	%xmm0, %xmm9
-	vpxor	%xmm7, %xmm8, %xmm10
-	vaesenc	%xmm0, %xmm2, %xmm0
-	vaesenc	%xmm2, %xmm4, %xmm2
-	vaesenc	%xmm4, %xmm8, %xmm4
-	vaesenc	%xmm10, %xmm1, %xmm8
-	vpxor	%xmm7, %xmm6, %xmm7
+	vaesenc	%xmm3, %xmm9, %xmm3
+	vaesenc	%xmm10, %xmm4, %xmm9
+	vmovdqu	%xmm6, %xmm4
+	vpxor	%xmm5, %xmm8, %xmm10
+	vaesenc	%xmm6, %xmm7, %xmm6
+	vaesenc	%xmm7, %xmm2, %xmm7
+	vaesenc	%xmm2, %xmm8, %xmm2
+	vaesenc	%xmm10, %xmm0, %xmm8
+	vpxor	%xmm5, %xmm9, %xmm10
+	vaesenc	%xmm0, %xmm1, %xmm0
 	vaesenc	%xmm1, %xmm3, %xmm1
-	vaesenc	%xmm3, %xmm5, %xmm3
-	vaesenc	%xmm5, %xmm6, %xmm5
-	vaesenc	%xmm7, %xmm9, %xmm6
+	vaesenc	%xmm3, %xmm9, %xmm3
+	vaesenc	%xmm10, %xmm4, %xmm4
+	vmovdqu	%xmm6, %xmm9
+	vpxor	%xmm5, %xmm8, %xmm10
+	vaesenc	%xmm6, %xmm7, %xmm6
+	vaesenc	%xmm7, %xmm2, %xmm7
+	vaesenc	%xmm2, %xmm8, %xmm2
+	vaesenc	%xmm10, %xmm0, %xmm8
+	vpxor	%xmm5, %xmm4, %xmm5
+	vaesenc	%xmm0, %xmm1, %xmm0
+	vaesenc	%xmm1, %xmm3, %xmm1
+	vaesenc	%xmm3, %xmm4, %xmm3
+	vaesenc	%xmm5, %xmm9, %xmm4
 	cmpb	$16, %dl
 	je  	L_aegis128l_encrypt$1
-	vpxor	%xmm5, %xmm6, %xmm5
-	vpxor	%xmm4, %xmm8, %xmm4
-	vpxor	%xmm3, %xmm5, %xmm3
-	vpxor	%xmm2, %xmm4, %xmm2
+	vpxor	%xmm3, %xmm4, %xmm3
+	vpxor	%xmm2, %xmm8, %xmm2
 	vpxor	%xmm1, %xmm3, %xmm1
-	vpxor	%xmm0, %xmm2, %xmm0
-	vmovdqu	%xmm1, (%rcx)
-	vmovdqu	%xmm0, 16(%rcx)
+	vpxor	%xmm7, %xmm2, %xmm2
+	vpxor	%xmm0, %xmm1, %xmm0
+	vpxor	%xmm6, %xmm2, %xmm1
+	vmovdqu	%xmm0, (%rcx)
+	vmovdqu	%xmm1, 16(%rcx)
 	jmp 	L_aegis128l_encrypt$2
 L_aegis128l_encrypt$1:
-	vpxor	%xmm5, %xmm6, %xmm0
-	vpxor	%xmm3, %xmm0, %xmm0
-	vpxor	%xmm1, %xmm0, %xmm0
+	vpxor	%xmm3, %xmm4, %xmm3
+	vpxor	%xmm1, %xmm3, %xmm1
+	vpxor	%xmm0, %xmm1, %xmm0
 	vpxor	%xmm8, %xmm0, %xmm0
-	vpxor	%xmm4, %xmm0, %xmm0
 	vpxor	%xmm2, %xmm0, %xmm0
+	vpxor	%xmm7, %xmm0, %xmm0
 	vmovdqu	%xmm0, (%rcx)
 L_aegis128l_encrypt$2:
 	movq	%r11, %rsp

--- a/src/aegis128x2/aegis128x2.jazz
+++ b/src/aegis128x2/aegis128x2.jazz
@@ -80,7 +80,7 @@ inline fn declast(#secret reg u256[8] st, #public reg u256[2] t,
     pad[1] = out[1];
     reg u64 i = left;
     while (i < 64) {
-        pad[u8(int) i] = 0;
+        pad[:u8 i] = 0;
         i += 1;
     }
     st = update(st, pad[0], pad[1]);
@@ -103,8 +103,8 @@ inline fn init(#public reg u64 key_p, #public reg u64 nonce_p)
 
     #secret reg u128 k0;
     #public reg u128 n0;
-    k0 = (u128)[key_p];
-    #declassify n0 = (u128)[nonce_p];
+    k0 = [:u128 key_p];
+    #declassify n0 = [:u128 nonce_p];
     #secret reg u256 k;
     #public reg u256 n;
     k = #VINSERTI128(k, k0, 0);
@@ -142,7 +142,8 @@ inline fn finalize(#secret reg u256[8] st,
                    #public inline bool verify)
     -> #secret reg u64
 {
-    reg u64 ret = #set0();
+    reg u64 ret;
+    ?{}, ret = #set0();
 
     stack u64[4] sizes;
     ad_len <<= 3;
@@ -151,7 +152,7 @@ inline fn finalize(#secret reg u256[8] st,
     sizes[2] = ad_len;
     sizes[1] = msg_len;
     sizes[3] = msg_len;
-    reg u256 t = st[2] ^ sizes[u256 0];
+    reg u256 t = st[2] ^ sizes[:u256 0];
 
     inline int i;
     for i = 0 to 7 {
@@ -173,14 +174,14 @@ inline fn finalize(#secret reg u256[8] st,
 
         if (verify) {
             reg u128 valid;
-            valid = (u128)[tag_p];
+            valid = [:u128 tag_p];
             valid = #VPCMPEQ_2u64(valid, tag);
-            ret = #VPMOVMSKB_u128u64(valid);
+            ret = (64u)#MOVEMASK_16u8(valid);
             ret += 1;
             ret >>= 16;
             ret -= 1;
         } else {
-            (u128)[tag_p] = tag;
+            [:u128 tag_p] = tag;
         }
     } else {
         reg u256[2] tag256;
@@ -199,18 +200,18 @@ inline fn finalize(#secret reg u256[8] st,
 
         if (verify) {
             reg u128[2] valid;
-            valid[0] = (u128)[tag_p];
-            valid[1] = (u128)[tag_p + 16];
+            valid[0] = [:u128 tag_p];
+            valid[1] = [:u128 tag_p + 16];
             valid[0] = #VPCMPEQ_2u64(valid[0], tag[0]);
             valid[1] = #VPCMPEQ_2u64(valid[1], tag[1]);
             valid[0] &= valid[1];
-            ret = #VPMOVMSKB_u128u64(valid[0]);
+            ret = (64u)#MOVEMASK_16u8(valid[0]);
             ret += 1;
             ret >>= 16;
             ret -= 1;
         } else {
-            (u128)[tag_p] = tag[0];
-            (u128)[tag_p + 16] = tag[1];
+            [:u128 tag_p] = tag[0];
+            [:u128 tag_p + 16] = tag[1];
         }
     }
     for i = 0 to 8 {
@@ -226,16 +227,16 @@ export fn _aegis128x2_encrypt(#public reg u64 params)
     #public stack u64 ad_len_ msg_len_;
     #public reg u8 tag_len;
 
-    #declassify ct_p = (u64)[params + 8 * 0];
-    // ignored: ct_len = (u64)[params + 8 * 1];
-    #declassify tag_p = (u64)[params + 8 * 2];
-    #declassify tag_len = (u8)[params + 8 * 3];
-    #declassify msg_p = (u64)[params + 8 * 4];
-    #declassify msg_len_ = (u64)[params + 8 * 5];
-    #declassify ad_p = (u64)[params + 8 * 6];
-    #declassify ad_len_ = (u64)[params + 8 * 7];
-    #declassify key_p = (u64)[params + 8 * 8];
-    #declassify nonce_p = (u64)[params + 8 * 9];
+    #declassify ct_p = [:u64 params + 8 * 0];
+    // ignored: ct_len = [:u64 params + 8 * 1];
+    #declassify tag_p = [:u64 params + 8 * 2];
+    #declassify tag_len = [:u8 params + 8 * 3];
+    #declassify msg_p = [:u64 params + 8 * 4];
+    #declassify msg_len_ = [:u64 params + 8 * 5];
+    #declassify ad_p = [:u64 params + 8 * 6];
+    #declassify ad_len_ = [:u64 params + 8 * 7];
+    #declassify key_p = [:u64 params + 8 * 8];
+    #declassify nonce_p = [:u64 params + 8 * 9];
 
     #secret reg u256[8] st;
     st = init(key_p, nonce_p);
@@ -246,12 +247,13 @@ export fn _aegis128x2_encrypt(#public reg u64 params)
     full_blocks = ad_len_;
     full_blocks = full_blocks & -64;
 
-    reg u64 i = #set0();
+    reg u64 i;
+    ?{}, i = #set0();
 
     #align while (i < full_blocks) {
         reg u256[2] t;
-        t[0] = (u256)[ad_p + i];
-        t[1] = (u256)[ad_p + i + 32];
+        t[0] = [:u256 ad_p + i];
+        t[1] = [:u256 ad_p + i + 32];
         st = absorb(st, t);
         i += 64;
     }
@@ -267,9 +269,9 @@ export fn _aegis128x2_encrypt(#public reg u64 params)
         pad[0] = zero;
         pad[1] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[ad_p + i];
+            pad[:u8 i] = [:u8 ad_p + i];
             i += 1;
         }
 
@@ -285,15 +287,15 @@ export fn _aegis128x2_encrypt(#public reg u64 params)
     full_blocks = msg_len_;
     full_blocks = full_blocks & -64;
 
-    i = #set0();
+    ?{}, i = #set0();
     #align while (i < full_blocks) {
         reg u256[2] t;
-        t[0] = (u256)[msg_p + i];
-        t[1] = (u256)[msg_p + i + 32];
+        t[0] = [:u256 msg_p + i];
+        t[1] = [:u256 msg_p + i + 32];
         reg u256[2] out;
         st, out = enc(st, t);
-        (u256)[ct_p + i] = out[0];
-        (u256)[ct_p + i + 32] = out[1];
+        [:u256 ct_p + i] = out[0];
+        [:u256 ct_p + i + 32] = out[1];
         i += 64;
     }
 
@@ -308,9 +310,9 @@ export fn _aegis128x2_encrypt(#public reg u64 params)
         pad[0] = zero;
         pad[1] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[msg_p + i];
+            pad[:u8 i] = [:u8 msg_p + i];
             i += 1;
         }
 
@@ -323,9 +325,9 @@ export fn _aegis128x2_encrypt(#public reg u64 params)
         pad[0] = out[0];
         pad[1] = out[1];
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            (u8)[ct_p + i] = pad[u8(int) i];
+            [:u8 ct_p + i] = pad[:u8 i];
             i += 1;
         }
     }
@@ -344,16 +346,16 @@ export fn _aegis128x2_decrypt(#public reg u64 params)
     #public stack u64 ad_len_ ct_len_;
     #public reg u8 tag_len;
 
-    #declassify ct_p = (u64)[params + 8 * 0];
-    #declassify ct_len_ = (u64)[params + 8 * 1];
-    #declassify tag_p = (u64)[params + 8 * 2];
-    #declassify tag_len = (u8)[params + 8 * 3];
-    #declassify msg_p = (u64)[params + 8 * 4];
-    // ignored: msg_len_ = (u64)[params + 8 * 5];
-    #declassify ad_p = (u64)[params + 8 * 6];
-    #declassify ad_len_ = (u64)[params + 8 * 7];
-    #declassify key_p = (u64)[params + 8 * 8];
-    #declassify nonce_p = (u64)[params + 8 * 9];
+    #declassify ct_p = [:u64 params + 8 * 0];
+    #declassify ct_len_ = [:u64 params + 8 * 1];
+    #declassify tag_p = [:u64 params + 8 * 2];
+    #declassify tag_len = [:u8 params + 8 * 3];
+    #declassify msg_p = [:u64 params + 8 * 4];
+    // ignored: msg_len_ = [:u64 params + 8 * 5];
+    #declassify ad_p = [:u64 params + 8 * 6];
+    #declassify ad_len_ = [:u64 params + 8 * 7];
+    #declassify key_p = [:u64 params + 8 * 8];
+    #declassify nonce_p = [:u64 params + 8 * 9];
 
     #secret reg u256[8] st;
     st = init(key_p, nonce_p);
@@ -364,11 +366,12 @@ export fn _aegis128x2_decrypt(#public reg u64 params)
     full_blocks = ad_len_;
     full_blocks = full_blocks & -64;
 
-    reg u64 i = #set0();
+    reg u64 i;
+    ?{}, i = #set0();
     #align while (i < full_blocks) {
         reg u256[2] t;
-        t[0] = (u256)[ad_p + i];
-        t[1] = (u256)[ad_p + i + 32];
+        t[0] = [:u256 ad_p + i];
+        t[1] = [:u256 ad_p + i + 32];
         st = absorb(st, t);
         i += 64;
     }
@@ -384,9 +387,9 @@ export fn _aegis128x2_decrypt(#public reg u64 params)
         pad[0] = zero;
         pad[1] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[ad_p + i];
+            pad[:u8 i] = [:u8 ad_p + i];
             i += 1;
         }
 
@@ -402,15 +405,15 @@ export fn _aegis128x2_decrypt(#public reg u64 params)
     full_blocks = ct_len_;
     full_blocks = full_blocks & -64;
 
-    i = #set0();
+    ?{}, i = #set0();
     #align while (i < full_blocks) {
         #public reg u256[2] t;
-        #declassify t[0] = (u256)[ct_p + i];
-        #declassify t[1] = (u256)[ct_p + i + 32];
+        #declassify t[0] = [:u256 ct_p + i];
+        #declassify t[1] = [:u256 ct_p + i + 32];
         #secret reg u256[2] out;
         st, out = dec(st, t);
-        (u256)[msg_p + i] = out[0];
-        (u256)[msg_p + i + 32] = out[1];
+        [:u256 msg_p + i] = out[0];
+        [:u256 msg_p + i + 32] = out[1];
         i += 64;
     }
 
@@ -425,9 +428,9 @@ export fn _aegis128x2_decrypt(#public reg u64 params)
         pad[0] = zero;
         pad[1] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[ct_p + i];
+            pad[:u8 i] = [:u8 ct_p + i];
             i += 1;
         }
 
@@ -440,9 +443,9 @@ export fn _aegis128x2_decrypt(#public reg u64 params)
         pad[0] = out[0];
         pad[1] = out[1];
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            (u8)[msg_p + i] = pad[u8(int) i];
+            [:u8 msg_p + i] = pad[:u8 i];
             i += 1;
         }
     }

--- a/src/aegis128x2/aegis128x2.s
+++ b/src/aegis128x2/aegis128x2.s
@@ -1,10 +1,10 @@
 	.att_syntax
 	.text
 	.p2align	5
-	.globl	__aegis128x2_decrypt
-	.globl	_aegis128x2_decrypt
-	.globl	__aegis128x2_encrypt
-	.globl	_aegis128x2_encrypt
+	.global	__aegis128x2_decrypt
+	.global	_aegis128x2_decrypt
+	.global	__aegis128x2_encrypt
+	.global	_aegis128x2_encrypt
 __aegis128x2_decrypt:
 _aegis128x2_decrypt:
 	movq	%rsp, %r11
@@ -167,7 +167,7 @@ _aegis128x2_decrypt:
 	vaesenc	%ymm11, %ymm9, %ymm9
 	movq	168(%rsp), %rdi
 	andq	$-64, %rdi
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis128x2_decrypt$15
 	.p2align	5
 L_aegis128x2_decrypt$16:
@@ -196,7 +196,7 @@ L_aegis128x2_decrypt$15:
 	vpxor	%ymm7, %ymm7, %ymm7
 	vmovdqu	%ymm7, 32(%rsp)
 	vmovdqu	%ymm7, 64(%rsp)
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis128x2_decrypt$13
 L_aegis128x2_decrypt$14:
 	movb	(%r8,%r9), %r10b
@@ -221,7 +221,7 @@ L_aegis128x2_decrypt$13:
 L_aegis128x2_decrypt$12:
 	movq	160(%rsp), %rdi
 	andq	$-64, %rdi
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis128x2_decrypt$10
 	.p2align	5
 L_aegis128x2_decrypt$11:
@@ -261,7 +261,7 @@ L_aegis128x2_decrypt$10:
 	vpxor	%ymm7, %ymm7, %ymm7
 	vmovdqu	%ymm7, 32(%rsp)
 	vmovdqu	%ymm7, 64(%rsp)
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis128x2_decrypt$8
 L_aegis128x2_decrypt$9:
 	movb	(%rax,%r8), %r9b
@@ -305,7 +305,7 @@ L_aegis128x2_decrypt$6:
 	vaesenc	%ymm10, %ymm12, %ymm9
 	vmovdqu	%ymm8, 32(%rsp)
 	vmovdqu	%ymm7, 64(%rsp)
-	xorq	%rax, %rax
+	xorl	%eax, %eax
 	jmp 	L_aegis128x2_decrypt$4
 L_aegis128x2_decrypt$5:
 	movb	32(%rsp,%rax), %r8b
@@ -317,7 +317,6 @@ L_aegis128x2_decrypt$4:
 L_aegis128x2_decrypt$3:
 	movq	168(%rsp), %rax
 	movq	160(%rsp), %rsi
-	xorq	%rdi, %rdi
 	shlq	$3, %rax
 	shlq	$3, %rsi
 	movq	%rax, (%rsp)
@@ -419,10 +418,10 @@ L_aegis128x2_decrypt$3:
 	vpcmpeqq	%xmm1, %xmm2, %xmm1
 	vpcmpeqq	%xmm0, %xmm3, %xmm0
 	vpand	%xmm0, %xmm1, %xmm0
-	vpmovmskb	%xmm0, %rax
+	vpmovmskb	%xmm0, %eax
 	incq	%rax
 	shrq	$16, %rax
-	addq	$-1, %rax
+	decq	%rax
 	jmp 	L_aegis128x2_decrypt$2
 L_aegis128x2_decrypt$1:
 	vpxor	%ymm5, %ymm6, %ymm0
@@ -435,10 +434,10 @@ L_aegis128x2_decrypt$1:
 	vpxor	%xmm0, %xmm1, %xmm0
 	vmovdqu	(%rcx), %xmm1
 	vpcmpeqq	%xmm0, %xmm1, %xmm0
-	vpmovmskb	%xmm0, %rax
+	vpmovmskb	%xmm0, %eax
 	incq	%rax
 	shrq	$16, %rax
-	addq	$-1, %rax
+	decq	%rax
 L_aegis128x2_decrypt$2:
 	movq	%r11, %rsp
 	movq	%rsp, %rsi
@@ -589,54 +588,54 @@ _aegis128x2_encrypt:
 	vaesenc	%ymm4, %ymm5, %ymm4
 	vaesenc	%ymm11, %ymm9, %ymm5
 	vpxor	%ymm1, %ymm8, %ymm11
-	vaesenc	%ymm9, %ymm6, %ymm12
+	vaesenc	%ymm9, %ymm6, %ymm9
 	vaesenc	%ymm6, %ymm7, %ymm6
 	vaesenc	%ymm7, %ymm8, %ymm7
-	vaesenc	%ymm11, %ymm10, %ymm9
-	vpxor	glob_data + 0(%rip), %ymm12, %ymm10
+	vaesenc	%ymm11, %ymm10, %ymm10
+	vpxor	glob_data + 0(%rip), %ymm9, %ymm9
 	vpxor	glob_data + 0(%rip), %ymm2, %ymm2
 	vmovdqu	%ymm2, %ymm11
-	vpxor	%ymm0, %ymm5, %ymm12
+	vpxor	%ymm0, %ymm5, %ymm8
 	vaesenc	%ymm2, %ymm3, %ymm2
-	vaesenc	%ymm3, %ymm4, %ymm8
+	vaesenc	%ymm3, %ymm4, %ymm3
 	vaesenc	%ymm4, %ymm5, %ymm4
-	vaesenc	%ymm12, %ymm10, %ymm5
-	vpxor	%ymm1, %ymm9, %ymm3
-	vaesenc	%ymm10, %ymm6, %ymm10
-	vaesenc	%ymm6, %ymm7, %ymm6
-	vaesenc	%ymm7, %ymm9, %ymm7
-	vaesenc	%ymm3, %ymm11, %ymm9
-	vpxor	glob_data + 0(%rip), %ymm10, %ymm11
+	vaesenc	%ymm8, %ymm9, %ymm8
+	vpxor	%ymm1, %ymm10, %ymm5
+	vaesenc	%ymm9, %ymm6, %ymm12
+	vaesenc	%ymm6, %ymm7, %ymm9
+	vaesenc	%ymm7, %ymm10, %ymm7
+	vaesenc	%ymm5, %ymm11, %ymm10
+	vpxor	glob_data + 0(%rip), %ymm12, %ymm12
 	vpxor	glob_data + 0(%rip), %ymm2, %ymm2
-	vmovdqu	%ymm2, %ymm10
-	vpxor	%ymm0, %ymm5, %ymm12
-	vaesenc	%ymm2, %ymm8, %ymm3
-	vaesenc	%ymm8, %ymm4, %ymm2
-	vaesenc	%ymm4, %ymm5, %ymm0
-	vaesenc	%ymm12, %ymm11, %ymm4
-	vpxor	%ymm1, %ymm9, %ymm8
-	vaesenc	%ymm11, %ymm6, %ymm1
-	vaesenc	%ymm6, %ymm7, %ymm5
-	vaesenc	%ymm7, %ymm9, %ymm6
-	vaesenc	%ymm8, %ymm10, %ymm9
+	vmovdqu	%ymm2, %ymm11
+	vpxor	%ymm0, %ymm8, %ymm0
+	vaesenc	%ymm2, %ymm3, %ymm6
+	vaesenc	%ymm3, %ymm4, %ymm5
+	vaesenc	%ymm4, %ymm8, %ymm4
+	vaesenc	%ymm0, %ymm12, %ymm3
+	vpxor	%ymm1, %ymm10, %ymm8
+	vaesenc	%ymm12, %ymm9, %ymm2
+	vaesenc	%ymm9, %ymm7, %ymm1
+	vaesenc	%ymm7, %ymm10, %ymm0
+	vaesenc	%ymm8, %ymm11, %ymm9
 	movq	104(%rsp), %rdi
 	andq	$-64, %rdi
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis128x2_encrypt$13
 	.p2align	5
 L_aegis128x2_encrypt$14:
 	vmovdqu	(%r8,%r9), %ymm7
 	vmovdqu	32(%r8,%r9), %ymm8
-	vmovdqu	%ymm3, %ymm10
-	vpxor	%ymm8, %ymm4, %ymm8
-	vaesenc	%ymm3, %ymm2, %ymm3
-	vaesenc	%ymm2, %ymm0, %ymm2
-	vaesenc	%ymm0, %ymm4, %ymm0
-	vaesenc	%ymm8, %ymm1, %ymm4
+	vmovdqu	%ymm6, %ymm10
+	vpxor	%ymm8, %ymm3, %ymm8
+	vaesenc	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm5, %ymm4, %ymm5
+	vaesenc	%ymm4, %ymm3, %ymm4
+	vaesenc	%ymm8, %ymm2, %ymm3
 	vpxor	%ymm7, %ymm9, %ymm7
-	vaesenc	%ymm1, %ymm5, %ymm1
-	vaesenc	%ymm5, %ymm6, %ymm5
-	vaesenc	%ymm6, %ymm9, %ymm6
+	vaesenc	%ymm2, %ymm1, %ymm2
+	vaesenc	%ymm1, %ymm0, %ymm1
+	vaesenc	%ymm0, %ymm9, %ymm0
 	vaesenc	%ymm7, %ymm10, %ymm9
 	addq	$64, %r9
 L_aegis128x2_encrypt$13:
@@ -650,7 +649,7 @@ L_aegis128x2_encrypt$13:
 	vpxor	%ymm7, %ymm7, %ymm7
 	vmovdqu	%ymm7, 32(%rsp)
 	vmovdqu	%ymm7, 64(%rsp)
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis128x2_encrypt$11
 L_aegis128x2_encrypt$12:
 	movb	(%r8,%r9), %r10b
@@ -661,44 +660,44 @@ L_aegis128x2_encrypt$11:
 	jb  	L_aegis128x2_encrypt$12
 	vmovdqu	32(%rsp), %ymm7
 	vmovdqu	64(%rsp), %ymm8
-	vmovdqu	%ymm3, %ymm10
-	vpxor	%ymm8, %ymm4, %ymm8
-	vaesenc	%ymm3, %ymm2, %ymm3
-	vaesenc	%ymm2, %ymm0, %ymm2
-	vaesenc	%ymm0, %ymm4, %ymm0
-	vaesenc	%ymm8, %ymm1, %ymm4
+	vmovdqu	%ymm6, %ymm10
+	vpxor	%ymm8, %ymm3, %ymm8
+	vaesenc	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm5, %ymm4, %ymm5
+	vaesenc	%ymm4, %ymm3, %ymm4
+	vaesenc	%ymm8, %ymm2, %ymm3
 	vpxor	%ymm7, %ymm9, %ymm7
-	vaesenc	%ymm1, %ymm5, %ymm1
-	vaesenc	%ymm5, %ymm6, %ymm5
-	vaesenc	%ymm6, %ymm9, %ymm6
+	vaesenc	%ymm2, %ymm1, %ymm2
+	vaesenc	%ymm1, %ymm0, %ymm1
+	vaesenc	%ymm0, %ymm9, %ymm0
 	vaesenc	%ymm7, %ymm10, %ymm9
 L_aegis128x2_encrypt$10:
 	movq	96(%rsp), %rdi
 	andq	$-64, %rdi
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis128x2_encrypt$8
 	.p2align	5
 L_aegis128x2_encrypt$9:
 	vmovdqu	(%rsi,%r8), %ymm7
 	vmovdqu	32(%rsi,%r8), %ymm8
-	vpand	%ymm1, %ymm5, %ymm10
-	vpand	%ymm3, %ymm2, %ymm11
-	vpxor	%ymm6, %ymm2, %ymm12
-	vpxor	%ymm0, %ymm5, %ymm13
+	vpand	%ymm2, %ymm1, %ymm10
+	vpand	%ymm6, %ymm5, %ymm11
+	vpxor	%ymm0, %ymm5, %ymm12
+	vpxor	%ymm4, %ymm1, %ymm13
 	vpxor	%ymm10, %ymm12, %ymm10
 	vpxor	%ymm11, %ymm13, %ymm11
 	vpxor	%ymm10, %ymm7, %ymm10
 	vpxor	%ymm11, %ymm8, %ymm11
-	vmovdqu	%ymm3, %ymm12
-	vpxor	%ymm8, %ymm4, %ymm8
-	vaesenc	%ymm3, %ymm2, %ymm3
-	vaesenc	%ymm2, %ymm0, %ymm2
-	vaesenc	%ymm0, %ymm4, %ymm0
-	vaesenc	%ymm8, %ymm1, %ymm4
+	vmovdqu	%ymm6, %ymm12
+	vpxor	%ymm8, %ymm3, %ymm8
+	vaesenc	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm5, %ymm4, %ymm5
+	vaesenc	%ymm4, %ymm3, %ymm4
+	vaesenc	%ymm8, %ymm2, %ymm3
 	vpxor	%ymm7, %ymm9, %ymm7
-	vaesenc	%ymm1, %ymm5, %ymm1
-	vaesenc	%ymm5, %ymm6, %ymm5
-	vaesenc	%ymm6, %ymm9, %ymm6
+	vaesenc	%ymm2, %ymm1, %ymm2
+	vaesenc	%ymm1, %ymm0, %ymm1
+	vaesenc	%ymm0, %ymm9, %ymm0
 	vaesenc	%ymm7, %ymm12, %ymm9
 	vmovdqu	%ymm10, (%rax,%r8)
 	vmovdqu	%ymm11, 32(%rax,%r8)
@@ -715,7 +714,7 @@ L_aegis128x2_encrypt$8:
 	vpxor	%ymm7, %ymm7, %ymm7
 	vmovdqu	%ymm7, 32(%rsp)
 	vmovdqu	%ymm7, 64(%rsp)
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis128x2_encrypt$6
 L_aegis128x2_encrypt$7:
 	movb	(%rsi,%r8), %r9b
@@ -726,28 +725,28 @@ L_aegis128x2_encrypt$6:
 	jb  	L_aegis128x2_encrypt$7
 	vmovdqu	32(%rsp), %ymm7
 	vmovdqu	64(%rsp), %ymm8
-	vpand	%ymm1, %ymm5, %ymm10
-	vpand	%ymm3, %ymm2, %ymm11
-	vpxor	%ymm6, %ymm2, %ymm12
-	vpxor	%ymm0, %ymm5, %ymm13
+	vpand	%ymm2, %ymm1, %ymm10
+	vpand	%ymm6, %ymm5, %ymm11
+	vpxor	%ymm0, %ymm5, %ymm12
+	vpxor	%ymm4, %ymm1, %ymm13
 	vpxor	%ymm10, %ymm12, %ymm10
 	vpxor	%ymm11, %ymm13, %ymm11
 	vpxor	%ymm10, %ymm7, %ymm10
 	vpxor	%ymm11, %ymm8, %ymm11
-	vmovdqu	%ymm3, %ymm12
-	vpxor	%ymm8, %ymm4, %ymm8
-	vaesenc	%ymm3, %ymm2, %ymm3
-	vaesenc	%ymm2, %ymm0, %ymm2
-	vaesenc	%ymm0, %ymm4, %ymm0
-	vaesenc	%ymm8, %ymm1, %ymm4
+	vmovdqu	%ymm6, %ymm12
+	vpxor	%ymm8, %ymm3, %ymm8
+	vaesenc	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm5, %ymm4, %ymm5
+	vaesenc	%ymm4, %ymm3, %ymm4
+	vaesenc	%ymm8, %ymm2, %ymm3
 	vpxor	%ymm7, %ymm9, %ymm7
-	vaesenc	%ymm1, %ymm5, %ymm1
-	vaesenc	%ymm5, %ymm6, %ymm5
-	vaesenc	%ymm6, %ymm9, %ymm6
+	vaesenc	%ymm2, %ymm1, %ymm2
+	vaesenc	%ymm1, %ymm0, %ymm1
+	vaesenc	%ymm0, %ymm9, %ymm0
 	vaesenc	%ymm7, %ymm12, %ymm9
 	vmovdqu	%ymm10, 32(%rsp)
 	vmovdqu	%ymm11, 64(%rsp)
-	xorq	%rsi, %rsi
+	xorl	%esi, %esi
 	jmp 	L_aegis128x2_encrypt$4
 L_aegis128x2_encrypt$5:
 	movb	32(%rsp,%rsi), %r8b
@@ -759,99 +758,99 @@ L_aegis128x2_encrypt$4:
 L_aegis128x2_encrypt$3:
 	movq	104(%rsp), %rsi
 	movq	96(%rsp), %rdi
-	xorq	%rax, %rax
+	xorl	%eax, %eax
 	shlq	$3, %rsi
 	shlq	$3, %rdi
 	movq	%rsi, (%rsp)
 	movq	%rsi, 16(%rsp)
 	movq	%rdi, 8(%rsp)
 	movq	%rdi, 24(%rsp)
-	vpxor	(%rsp), %ymm5, %ymm7
-	vmovdqu	%ymm3, %ymm8
+	vpxor	(%rsp), %ymm1, %ymm7
+	vmovdqu	%ymm6, %ymm8
+	vpxor	%ymm7, %ymm3, %ymm10
+	vaesenc	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm5, %ymm4, %ymm5
+	vaesenc	%ymm4, %ymm3, %ymm3
+	vaesenc	%ymm10, %ymm2, %ymm4
+	vpxor	%ymm7, %ymm9, %ymm10
+	vaesenc	%ymm2, %ymm1, %ymm2
+	vaesenc	%ymm1, %ymm0, %ymm1
+	vaesenc	%ymm0, %ymm9, %ymm0
+	vaesenc	%ymm10, %ymm8, %ymm9
+	vmovdqu	%ymm6, %ymm8
 	vpxor	%ymm7, %ymm4, %ymm10
-	vaesenc	%ymm3, %ymm2, %ymm3
-	vaesenc	%ymm2, %ymm0, %ymm2
-	vaesenc	%ymm0, %ymm4, %ymm4
-	vaesenc	%ymm10, %ymm1, %ymm10
-	vpxor	%ymm7, %ymm9, %ymm11
-	vaesenc	%ymm1, %ymm5, %ymm0
-	vaesenc	%ymm5, %ymm6, %ymm1
-	vaesenc	%ymm6, %ymm9, %ymm5
-	vaesenc	%ymm11, %ymm8, %ymm9
-	vmovdqu	%ymm3, %ymm6
-	vpxor	%ymm7, %ymm10, %ymm8
-	vaesenc	%ymm3, %ymm2, %ymm3
-	vaesenc	%ymm2, %ymm4, %ymm2
-	vaesenc	%ymm4, %ymm10, %ymm4
-	vaesenc	%ymm8, %ymm0, %ymm8
+	vaesenc	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm5, %ymm3, %ymm5
+	vaesenc	%ymm3, %ymm4, %ymm3
+	vaesenc	%ymm10, %ymm2, %ymm4
 	vpxor	%ymm7, %ymm9, %ymm10
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm1, %ymm5, %ymm1
-	vaesenc	%ymm5, %ymm9, %ymm5
-	vaesenc	%ymm10, %ymm6, %ymm9
-	vmovdqu	%ymm3, %ymm6
-	vpxor	%ymm7, %ymm8, %ymm10
-	vaesenc	%ymm3, %ymm2, %ymm3
-	vaesenc	%ymm2, %ymm4, %ymm2
-	vaesenc	%ymm4, %ymm8, %ymm4
-	vaesenc	%ymm10, %ymm0, %ymm8
+	vaesenc	%ymm2, %ymm1, %ymm2
+	vaesenc	%ymm1, %ymm0, %ymm1
+	vaesenc	%ymm0, %ymm9, %ymm0
+	vaesenc	%ymm10, %ymm8, %ymm9
+	vmovdqu	%ymm6, %ymm8
+	vpxor	%ymm7, %ymm4, %ymm10
+	vaesenc	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm5, %ymm3, %ymm5
+	vaesenc	%ymm3, %ymm4, %ymm3
+	vaesenc	%ymm10, %ymm2, %ymm4
 	vpxor	%ymm7, %ymm9, %ymm10
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm1, %ymm5, %ymm1
-	vaesenc	%ymm5, %ymm9, %ymm5
-	vaesenc	%ymm10, %ymm6, %ymm9
-	vmovdqu	%ymm3, %ymm6
-	vpxor	%ymm7, %ymm8, %ymm10
-	vaesenc	%ymm3, %ymm2, %ymm3
-	vaesenc	%ymm2, %ymm4, %ymm2
-	vaesenc	%ymm4, %ymm8, %ymm4
-	vaesenc	%ymm10, %ymm0, %ymm8
+	vaesenc	%ymm2, %ymm1, %ymm2
+	vaesenc	%ymm1, %ymm0, %ymm1
+	vaesenc	%ymm0, %ymm9, %ymm0
+	vaesenc	%ymm10, %ymm8, %ymm9
+	vmovdqu	%ymm6, %ymm8
+	vpxor	%ymm7, %ymm4, %ymm10
+	vaesenc	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm5, %ymm3, %ymm5
+	vaesenc	%ymm3, %ymm4, %ymm3
+	vaesenc	%ymm10, %ymm2, %ymm4
 	vpxor	%ymm7, %ymm9, %ymm10
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm1, %ymm5, %ymm1
-	vaesenc	%ymm5, %ymm9, %ymm5
-	vaesenc	%ymm10, %ymm6, %ymm9
-	vmovdqu	%ymm3, %ymm6
-	vpxor	%ymm7, %ymm8, %ymm10
-	vaesenc	%ymm3, %ymm2, %ymm3
-	vaesenc	%ymm2, %ymm4, %ymm2
-	vaesenc	%ymm4, %ymm8, %ymm4
-	vaesenc	%ymm10, %ymm0, %ymm8
+	vaesenc	%ymm2, %ymm1, %ymm2
+	vaesenc	%ymm1, %ymm0, %ymm1
+	vaesenc	%ymm0, %ymm9, %ymm0
+	vaesenc	%ymm10, %ymm8, %ymm9
+	vmovdqu	%ymm6, %ymm8
+	vpxor	%ymm7, %ymm4, %ymm10
+	vaesenc	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm5, %ymm3, %ymm5
+	vaesenc	%ymm3, %ymm4, %ymm3
+	vaesenc	%ymm10, %ymm2, %ymm4
 	vpxor	%ymm7, %ymm9, %ymm10
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm1, %ymm5, %ymm1
-	vaesenc	%ymm5, %ymm9, %ymm5
-	vaesenc	%ymm10, %ymm6, %ymm9
-	vmovdqu	%ymm3, %ymm6
-	vpxor	%ymm7, %ymm8, %ymm10
-	vaesenc	%ymm3, %ymm2, %ymm3
-	vaesenc	%ymm2, %ymm4, %ymm2
-	vaesenc	%ymm4, %ymm8, %ymm4
-	vaesenc	%ymm10, %ymm0, %ymm8
+	vaesenc	%ymm2, %ymm1, %ymm2
+	vaesenc	%ymm1, %ymm0, %ymm1
+	vaesenc	%ymm0, %ymm9, %ymm0
+	vaesenc	%ymm10, %ymm8, %ymm9
+	vmovdqu	%ymm6, %ymm8
+	vpxor	%ymm7, %ymm4, %ymm10
+	vaesenc	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm5, %ymm3, %ymm5
+	vaesenc	%ymm3, %ymm4, %ymm3
+	vaesenc	%ymm10, %ymm2, %ymm4
 	vpxor	%ymm7, %ymm9, %ymm10
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm1, %ymm5, %ymm1
-	vaesenc	%ymm5, %ymm9, %ymm5
-	vaesenc	%ymm10, %ymm6, %ymm6
-	vmovdqu	%ymm3, %ymm9
-	vpxor	%ymm7, %ymm8, %ymm10
-	vaesenc	%ymm3, %ymm2, %ymm3
-	vaesenc	%ymm2, %ymm4, %ymm2
-	vaesenc	%ymm4, %ymm8, %ymm4
-	vaesenc	%ymm10, %ymm0, %ymm8
-	vpxor	%ymm7, %ymm6, %ymm7
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm1, %ymm5, %ymm1
-	vaesenc	%ymm5, %ymm6, %ymm5
-	vaesenc	%ymm7, %ymm9, %ymm6
+	vaesenc	%ymm2, %ymm1, %ymm2
+	vaesenc	%ymm1, %ymm0, %ymm1
+	vaesenc	%ymm0, %ymm9, %ymm0
+	vaesenc	%ymm10, %ymm8, %ymm8
+	vmovdqu	%ymm6, %ymm9
+	vpxor	%ymm7, %ymm4, %ymm10
+	vaesenc	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm5, %ymm3, %ymm5
+	vaesenc	%ymm3, %ymm4, %ymm3
+	vaesenc	%ymm10, %ymm2, %ymm4
+	vpxor	%ymm7, %ymm8, %ymm7
+	vaesenc	%ymm2, %ymm1, %ymm2
+	vaesenc	%ymm1, %ymm0, %ymm1
+	vaesenc	%ymm0, %ymm8, %ymm0
+	vaesenc	%ymm7, %ymm9, %ymm7
 	cmpb	$16, %dl
 	je  	L_aegis128x2_encrypt$1
-	vpxor	%ymm5, %ymm6, %ymm5
-	vpxor	%ymm4, %ymm8, %ymm4
-	vpxor	%ymm1, %ymm5, %ymm1
-	vpxor	%ymm2, %ymm4, %ymm2
-	vpxor	%ymm0, %ymm1, %ymm0
-	vpxor	%ymm3, %ymm2, %ymm1
+	vpxor	%ymm0, %ymm7, %ymm0
+	vpxor	%ymm3, %ymm4, %ymm3
+	vpxor	%ymm1, %ymm0, %ymm0
+	vpxor	%ymm5, %ymm3, %ymm1
+	vpxor	%ymm2, %ymm0, %ymm0
+	vpxor	%ymm6, %ymm1, %ymm1
 	vextracti128	$1, %ymm0, %xmm2
 	vextracti128	$1, %ymm1, %xmm3
 	vpxor	%xmm0, %xmm2, %xmm0
@@ -860,12 +859,12 @@ L_aegis128x2_encrypt$3:
 	vmovdqu	%xmm1, 16(%rcx)
 	jmp 	L_aegis128x2_encrypt$2
 L_aegis128x2_encrypt$1:
-	vpxor	%ymm5, %ymm6, %ymm3
-	vpxor	%ymm1, %ymm3, %ymm1
-	vpxor	%ymm0, %ymm1, %ymm0
-	vpxor	%ymm8, %ymm0, %ymm0
-	vpxor	%ymm4, %ymm0, %ymm0
+	vpxor	%ymm0, %ymm7, %ymm0
+	vpxor	%ymm1, %ymm0, %ymm0
 	vpxor	%ymm2, %ymm0, %ymm0
+	vpxor	%ymm4, %ymm0, %ymm0
+	vpxor	%ymm3, %ymm0, %ymm0
+	vpxor	%ymm5, %ymm0, %ymm0
 	vextracti128	$1, %ymm0, %xmm1
 	vpxor	%xmm0, %xmm1, %xmm0
 	vmovdqu	%xmm0, (%rcx)

--- a/src/aegis256/aegis256.jazz
+++ b/src/aegis256/aegis256.jazz
@@ -83,7 +83,7 @@ inline fn declast(#secret reg u128[6] st, #public reg u128 t,
     pad[0] = out;
     reg u64 i = left;
     while (i < 16) {
-        pad[u8(int) i] = 0;
+        pad[:u8 i] = 0;
         i += 1;
     }
     st = update2(st, pad[0], st5);
@@ -100,10 +100,10 @@ inline fn init(#public reg u64 key_p, #public reg u64 nonce_p)
 
     #secret reg u128 k0 k1;
     #public reg u128 n0 n1;
-    k0 = (u128)[key_p];
-    k1 = (u128)[key_p + 16];
-    #declassify n0 = (u128)[nonce_p];
-    #declassify n1 = (u128)[nonce_p + 16];
+    k0 = [:u128 key_p];
+    k1 = [:u128 key_p + 16];
+    #declassify n0 = [:u128 nonce_p];
+    #declassify n1 = [:u128 nonce_p + 16];
 
     #secret reg u128 k0n0 k1n1 k0c0 k1c1;
 
@@ -136,14 +136,15 @@ inline fn finalize(#secret reg u128[6] st,
                    #public inline bool verify)
     -> #secret reg u64
 {
-    reg u64 ret = #set0();
+    reg u64 ret;
+    ?{}, ret = #set0();
 
     stack u64[2] sizes;
     ad_len <<= 3;
     msg_len <<= 3;
     sizes[0] = ad_len;
     sizes[1] = msg_len;
-    reg u128 t = st[3] ^ sizes[u128 0];
+    reg u128 t = st[3] ^ sizes[:u128 0];
 
     inline int i;
     for i = 0 to 7 {
@@ -160,14 +161,14 @@ inline fn finalize(#secret reg u128[6] st,
 
         if (verify) {
             reg u128 valid;
-            valid = (u128)[tag_p];
+            valid = [:u128 tag_p];
             valid = #VPCMPEQ_2u64(valid, tag);
-            ret = #VPMOVMSKB_u128u64(valid);
+            ret = (64u)#MOVEMASK_16u8(valid);
             ret += 1;
             ret >>= 16;
             ret -= 1;
         } else {
-            (u128)[tag_p] = tag;
+            [:u128 tag_p] = tag;
         }
     } else {
         reg u128[2] tag;
@@ -178,18 +179,18 @@ inline fn finalize(#secret reg u128[6] st,
 
         if (verify) {
             reg u128[2] valid;
-            valid[0] = (u128)[tag_p];
-            valid[1] = (u128)[tag_p + 16];
+            valid[0] = [:u128 tag_p];
+            valid[1] = [:u128 tag_p + 16];
             valid[0] = #VPCMPEQ_2u64(valid[0], tag[0]);
             valid[1] = #VPCMPEQ_2u64(valid[1], tag[1]);
             valid[0] &= valid[1];
-            ret = #VPMOVMSKB_u128u64(valid[0]);
+            ret = (64u)#MOVEMASK_16u8(valid[0]);
             ret += 1;
             ret >>= 16;
             ret -= 1;
         } else {
-            (u128)[tag_p] = tag[0];
-            (u128)[tag_p + 16] = tag[1];
+            [:u128 tag_p] = tag[0];
+            [:u128 tag_p + 16] = tag[1];
         }
     }
     for i = 0 to 6 {
@@ -205,16 +206,16 @@ export fn _aegis256_encrypt(#public reg u64 params)
     #public stack u64 ad_len_ msg_len_;
     #public reg u8 tag_len;
 
-    #declassify ct_p = (u64)[params + 8 * 0];
-    // ignored: ct_len = (u64)[params + 8 * 1];
-    #declassify tag_p = (u64)[params + 8 * 2];
-    #declassify tag_len = (u8)[params + 8 * 3];
-    #declassify msg_p = (u64)[params + 8 * 4];
-    #declassify msg_len_ = (u64)[params + 8 * 5];
-    #declassify ad_p = (u64)[params + 8 * 6];
-    #declassify ad_len_ = (u64)[params + 8 * 7];
-    #declassify key_p = (u64)[params + 8 * 8];
-    #declassify nonce_p = (u64)[params + 8 * 9];
+    #declassify ct_p = [:u64 params + 8 * 0];
+    // ignored: ct_len = [:u64 params + 8 * 1];
+    #declassify tag_p = [:u64 params + 8 * 2];
+    #declassify tag_len = [:u8 params + 8 * 3];
+    #declassify msg_p = [:u64 params + 8 * 4];
+    #declassify msg_len_ = [:u64 params + 8 * 5];
+    #declassify ad_p = [:u64 params + 8 * 6];
+    #declassify ad_len_ = [:u64 params + 8 * 7];
+    #declassify key_p = [:u64 params + 8 * 8];
+    #declassify nonce_p = [:u64 params + 8 * 9];
 
     #secret reg u128[6] st;
     st = init(key_p, nonce_p);
@@ -225,10 +226,11 @@ export fn _aegis256_encrypt(#public reg u64 params)
     full_blocks = ad_len_;
     full_blocks = full_blocks & -16;
 
-    reg u64 i = #set0();
+    reg u64 i;
+    ?{}, i = #set0();
 
     #align while (i < full_blocks) {
-        st = absorb(st, (u128)[ad_p + i]);
+        st = absorb(st, [:u128 ad_p + i]);
         i += 16;
     }
     reg u64 left;
@@ -242,9 +244,9 @@ export fn _aegis256_encrypt(#public reg u64 params)
         reg u128 zero = #set0_128();
         pad[0] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[ad_p + i];
+            pad[:u8 i] = [:u8 ad_p + i];
             i += 1;
         }
         st = absorb(st, pad[0]);
@@ -255,16 +257,16 @@ export fn _aegis256_encrypt(#public reg u64 params)
     full_blocks = msg_len_;
     full_blocks = full_blocks & -32;
 
-    i = #set0();
+    ?{}, i = #set0();
     #align while (i < full_blocks) {
-        st, (u128)[ct_p + i] = enc(st, (u128)[msg_p + i]);
-        st, (u128)[ct_p + i + 16] = enc(st, (u128)[msg_p + i + 16]);
+        st, [:u128 ct_p + i] = enc(st, [:u128 msg_p + i]);
+        st, [:u128 ct_p + i + 16] = enc(st, [:u128 msg_p + i + 16]);
         i += 32;
     }
     left = msg_len_;
     left -= i;
     if (left >= 16) {
-        st, (u128)[ct_p + i] = enc(st, (u128)[msg_p + i]);
+        st, [:u128 ct_p + i] = enc(st, [:u128 msg_p + i]);
         left -= 16;
         i += 16;
     }
@@ -276,17 +278,17 @@ export fn _aegis256_encrypt(#public reg u64 params)
         reg u128 zero = #set0_128();
         pad[0] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[msg_p + i];
+            pad[:u8 i] = [:u8 msg_p + i];
             i += 1;
         }
 
         st, pad[0] = enc(st, pad[0]);
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            (u8)[ct_p + i] = pad[u8(int) i];
+            [:u8 ct_p + i] = pad[:u8 i];
             i += 1;
         }
     }
@@ -305,16 +307,16 @@ export fn _aegis256_decrypt(#public reg u64 params)
     #public stack u64 ad_len_ ct_len_;
     #public reg u8 tag_len;
 
-    #declassify ct_p = (u64)[params + 8 * 0];
-    #declassify ct_len_ = (u64)[params + 8 * 1];
-    #declassify tag_p = (u64)[params + 8 * 2];
-    #declassify tag_len = (u8)[params + 8 * 3];
-    #declassify msg_p = (u64)[params + 8 * 4];
-    // ignored: msg_len_ = (u64)[params + 8 * 5];
-    #declassify ad_p = (u64)[params + 8 * 6];
-    #declassify ad_len_ = (u64)[params + 8 * 7];
-    #declassify key_p = (u64)[params + 8 * 8];
-    #declassify nonce_p = (u64)[params + 8 * 9];
+    #declassify ct_p = [:u64 params + 8 * 0];
+    #declassify ct_len_ = [:u64 params + 8 * 1];
+    #declassify tag_p = [:u64 params + 8 * 2];
+    #declassify tag_len = [:u8 params + 8 * 3];
+    #declassify msg_p = [:u64 params + 8 * 4];
+    // ignored: msg_len_ = [:u64 params + 8 * 5];
+    #declassify ad_p = [:u64 params + 8 * 6];
+    #declassify ad_len_ = [:u64 params + 8 * 7];
+    #declassify key_p = [:u64 params + 8 * 8];
+    #declassify nonce_p = [:u64 params + 8 * 9];
 
     #secret reg u128[6] st;
     st = init(key_p, nonce_p);
@@ -325,9 +327,10 @@ export fn _aegis256_decrypt(#public reg u64 params)
     full_blocks = ad_len_;
     full_blocks = full_blocks & -16;
 
-    reg u64 i = #set0();
+    reg u64 i;
+    ?{}, i = #set0();
     #align while (i < full_blocks) {
-        st = absorb(st, (u128)[ad_p + i]);
+        st = absorb(st, [:u128 ad_p + i]);
         i += 16;
     }
     reg u64 left;
@@ -341,9 +344,9 @@ export fn _aegis256_decrypt(#public reg u64 params)
         reg u128 zero = #set0_128();
         pad[0] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[ad_p + i];
+            pad[:u8 i] = [:u8 ad_p + i];
             i += 1;
         }
 
@@ -355,21 +358,21 @@ export fn _aegis256_decrypt(#public reg u64 params)
     full_blocks = ct_len_;
     full_blocks = full_blocks & -32;
 
-    i = #set0();
+    ?{}, i = #set0();
     #align while (i < full_blocks) {
         #public reg u128 t;
-        #declassify t = (u128)[ct_p + i];
-        st, (u128)[msg_p + i] = dec(st, t);
-        #declassify t = (u128)[ct_p + i + 16];
-        st, (u128)[msg_p + i + 16] = dec(st, t);
+        #declassify t = [:u128 ct_p + i];
+        st, [:u128 msg_p + i] = dec(st, t);
+        #declassify t = [:u128 ct_p + i + 16];
+        st, [:u128 msg_p + i + 16] = dec(st, t);
         i += 32;
     }
     left = ct_len_;
     left -= i;
     if (left > 16) {
         #public reg u128 t;
-        #declassify t = (u128)[ct_p + i];
-        st, (u128)[msg_p + i] = dec(st, t);
+        #declassify t = [:u128 ct_p + i];
+        st, [:u128 msg_p + i] = dec(st, t);
         left -= 16;
         i += 16;
     }
@@ -381,9 +384,9 @@ export fn _aegis256_decrypt(#public reg u64 params)
         reg u128 zero = #set0_128();
         pad[0] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[ct_p + i];
+            pad[:u8 i] = [:u8 ct_p + i];
             i += 1;
         }
 
@@ -392,9 +395,9 @@ export fn _aegis256_decrypt(#public reg u64 params)
 
         st, pad[0] = declast(st, t, left);
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            (u8)[msg_p + i] = pad[u8(int) i];
+            [:u8 msg_p + i] = pad[:u8 i];
             i += 1;
         }
     }

--- a/src/aegis256/aegis256.s
+++ b/src/aegis256/aegis256.s
@@ -1,10 +1,10 @@
 	.att_syntax
 	.text
 	.p2align	5
-	.globl	__aegis256_decrypt
-	.globl	_aegis256_decrypt
-	.globl	__aegis256_encrypt
-	.globl	_aegis256_encrypt
+	.global	__aegis256_decrypt
+	.global	_aegis256_decrypt
+	.global	__aegis256_encrypt
+	.global	_aegis256_encrypt
 __aegis256_decrypt:
 _aegis256_decrypt:
 	movq	%rsp, %r11
@@ -161,7 +161,7 @@ _aegis256_decrypt:
 	vaesenc	%xmm9, %xmm7, %xmm5
 	movq	40(%rsp), %rdi
 	andq	$-16, %rdi
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis256_decrypt$16
 	.p2align	5
 L_aegis256_decrypt$17:
@@ -185,7 +185,7 @@ L_aegis256_decrypt$16:
 	addq	%r9, %r8
 	vpxor	%xmm6, %xmm6, %xmm6
 	vmovdqu	%xmm6, (%rsp)
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis256_decrypt$14
 L_aegis256_decrypt$15:
 	movb	(%r8,%r9), %r10b
@@ -206,7 +206,7 @@ L_aegis256_decrypt$14:
 L_aegis256_decrypt$13:
 	movq	32(%rsp), %rdi
 	andq	$-32, %rdi
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis256_decrypt$11
 	.p2align	5
 L_aegis256_decrypt$12:
@@ -270,7 +270,7 @@ L_aegis256_decrypt$10:
 	addq	%r8, %rax
 	vpxor	%xmm6, %xmm6, %xmm6
 	vmovdqu	%xmm6, (%rsp)
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis256_decrypt$8
 L_aegis256_decrypt$9:
 	movb	(%rax,%r8), %r9b
@@ -304,7 +304,7 @@ L_aegis256_decrypt$6:
 	vaesenc	%xmm4, %xmm5, %xmm4
 	vaesenc	%xmm7, %xmm9, %xmm5
 	vmovdqu	%xmm6, (%rsp)
-	xorq	%rax, %rax
+	xorl	%eax, %eax
 	jmp 	L_aegis256_decrypt$4
 L_aegis256_decrypt$5:
 	movb	(%rsp,%rax), %r8b
@@ -316,7 +316,6 @@ L_aegis256_decrypt$4:
 L_aegis256_decrypt$3:
 	movq	40(%rsp), %rax
 	movq	32(%rsp), %rsi
-	xorq	%rdi, %rdi
 	shlq	$3, %rax
 	shlq	$3, %rsi
 	movq	%rax, (%rsp)
@@ -382,10 +381,10 @@ L_aegis256_decrypt$3:
 	vpcmpeqq	%xmm2, %xmm1, %xmm1
 	vpcmpeqq	%xmm0, %xmm3, %xmm0
 	vpand	%xmm0, %xmm1, %xmm0
-	vpmovmskb	%xmm0, %rax
+	vpmovmskb	%xmm0, %eax
 	incq	%rax
 	shrq	$16, %rax
-	addq	$-1, %rax
+	decq	%rax
 	jmp 	L_aegis256_decrypt$2
 L_aegis256_decrypt$1:
 	vpxor	%xmm4, %xmm5, %xmm4
@@ -395,10 +394,10 @@ L_aegis256_decrypt$1:
 	vpxor	%xmm0, %xmm1, %xmm0
 	vmovdqu	(%rcx), %xmm1
 	vpcmpeqq	%xmm0, %xmm1, %xmm0
-	vpmovmskb	%xmm0, %rax
+	vpmovmskb	%xmm0, %eax
 	incq	%rax
 	shrq	$16, %rax
-	addq	$-1, %rax
+	decq	%rax
 L_aegis256_decrypt$2:
 	movq	%r11, %rsp
 	movq	%rsp, %rsi
@@ -552,33 +551,33 @@ _aegis256_encrypt:
 	vaesenc	%xmm8, %xmm12, %xmm6
 	vpxor	%xmm2, %xmm6, %xmm2
 	vaesenc	%xmm9, %xmm0, %xmm7
-	vaesenc	%xmm0, %xmm1, %xmm0
-	vaesenc	%xmm1, %xmm5, %xmm1
-	vaesenc	%xmm5, %xmm4, %xmm8
-	vaesenc	%xmm4, %xmm6, %xmm6
-	vaesenc	%xmm2, %xmm9, %xmm9
-	vpxor	%xmm3, %xmm9, %xmm10
-	vaesenc	%xmm7, %xmm0, %xmm5
-	vaesenc	%xmm0, %xmm1, %xmm4
-	vaesenc	%xmm1, %xmm8, %xmm3
-	vaesenc	%xmm8, %xmm6, %xmm2
-	vaesenc	%xmm6, %xmm9, %xmm1
-	vaesenc	%xmm10, %xmm7, %xmm0
+	vaesenc	%xmm0, %xmm1, %xmm8
+	vaesenc	%xmm1, %xmm5, %xmm10
+	vaesenc	%xmm5, %xmm4, %xmm5
+	vaesenc	%xmm4, %xmm6, %xmm4
+	vaesenc	%xmm2, %xmm9, %xmm6
+	vpxor	%xmm3, %xmm6, %xmm9
+	vaesenc	%xmm7, %xmm8, %xmm0
+	vaesenc	%xmm8, %xmm10, %xmm1
+	vaesenc	%xmm10, %xmm5, %xmm2
+	vaesenc	%xmm5, %xmm4, %xmm3
+	vaesenc	%xmm4, %xmm6, %xmm4
+	vaesenc	%xmm9, %xmm7, %xmm5
 	movq	24(%rsp), %rdi
 	andq	$-16, %rdi
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis256_encrypt$14
 	.p2align	5
 L_aegis256_encrypt$15:
 	vmovdqu	(%r8,%r9), %xmm6
-	vmovdqu	%xmm5, %xmm7
-	vpxor	%xmm6, %xmm0, %xmm6
-	vaesenc	%xmm7, %xmm4, %xmm5
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm1, %xmm2
-	vaesenc	%xmm1, %xmm0, %xmm1
-	vaesenc	%xmm6, %xmm7, %xmm0
+	vmovdqu	%xmm0, %xmm7
+	vpxor	%xmm6, %xmm5, %xmm6
+	vaesenc	%xmm7, %xmm1, %xmm0
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm4, %xmm3
+	vaesenc	%xmm4, %xmm5, %xmm4
+	vaesenc	%xmm6, %xmm7, %xmm5
 	addq	$16, %r9
 L_aegis256_encrypt$14:
 	cmpq	%rdi, %r9
@@ -590,7 +589,7 @@ L_aegis256_encrypt$14:
 	addq	%r9, %r8
 	vpxor	%xmm6, %xmm6, %xmm6
 	vmovdqu	%xmm6, (%rsp)
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis256_encrypt$12
 L_aegis256_encrypt$13:
 	movb	(%r8,%r9), %r10b
@@ -600,48 +599,48 @@ L_aegis256_encrypt$12:
 	cmpq	%rdi, %r9
 	jb  	L_aegis256_encrypt$13
 	vmovdqu	(%rsp), %xmm6
-	vmovdqu	%xmm5, %xmm7
-	vpxor	%xmm6, %xmm0, %xmm6
-	vaesenc	%xmm7, %xmm4, %xmm5
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm1, %xmm2
-	vaesenc	%xmm1, %xmm0, %xmm1
-	vaesenc	%xmm6, %xmm7, %xmm0
+	vmovdqu	%xmm0, %xmm7
+	vpxor	%xmm6, %xmm5, %xmm6
+	vaesenc	%xmm7, %xmm1, %xmm0
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm4, %xmm3
+	vaesenc	%xmm4, %xmm5, %xmm4
+	vaesenc	%xmm6, %xmm7, %xmm5
 L_aegis256_encrypt$11:
 	movq	16(%rsp), %rdi
 	andq	$-32, %rdi
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis256_encrypt$9
 	.p2align	5
 L_aegis256_encrypt$10:
 	vmovdqu	(%rsi,%r8), %xmm6
-	vpxor	%xmm4, %xmm1, %xmm7
-	vpand	%xmm3, %xmm2, %xmm8
+	vpxor	%xmm1, %xmm4, %xmm7
+	vpand	%xmm2, %xmm3, %xmm8
 	vpxor	%xmm8, %xmm7, %xmm7
-	vpxor	%xmm5, %xmm7, %xmm7
+	vpxor	%xmm0, %xmm7, %xmm7
 	vpxor	%xmm7, %xmm6, %xmm7
-	vpxor	%xmm6, %xmm0, %xmm8
-	vaesenc	%xmm5, %xmm4, %xmm6
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm1, %xmm2
-	vaesenc	%xmm1, %xmm0, %xmm0
-	vaesenc	%xmm8, %xmm5, %xmm1
+	vpxor	%xmm6, %xmm5, %xmm8
+	vaesenc	%xmm0, %xmm1, %xmm6
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm4, %xmm3
+	vaesenc	%xmm4, %xmm5, %xmm4
+	vaesenc	%xmm8, %xmm0, %xmm5
 	vmovdqu	%xmm7, (%rax,%r8)
-	vmovdqu	16(%rsi,%r8), %xmm5
-	vpxor	%xmm4, %xmm0, %xmm7
-	vpand	%xmm3, %xmm2, %xmm8
+	vmovdqu	16(%rsi,%r8), %xmm0
+	vpxor	%xmm1, %xmm4, %xmm7
+	vpand	%xmm2, %xmm3, %xmm8
 	vpxor	%xmm8, %xmm7, %xmm7
 	vpxor	%xmm6, %xmm7, %xmm7
-	vpxor	%xmm7, %xmm5, %xmm7
-	vpxor	%xmm5, %xmm1, %xmm8
-	vaesenc	%xmm6, %xmm4, %xmm5
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm0, %xmm2
-	vaesenc	%xmm0, %xmm1, %xmm1
-	vaesenc	%xmm8, %xmm6, %xmm0
+	vpxor	%xmm7, %xmm0, %xmm7
+	vpxor	%xmm0, %xmm5, %xmm8
+	vaesenc	%xmm6, %xmm1, %xmm0
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm4, %xmm3
+	vaesenc	%xmm4, %xmm5, %xmm4
+	vaesenc	%xmm8, %xmm6, %xmm5
 	vmovdqu	%xmm7, 16(%rax,%r8)
 	addq	$32, %r8
 L_aegis256_encrypt$9:
@@ -652,19 +651,19 @@ L_aegis256_encrypt$9:
 	cmpq	$16, %rdi
 	jb  	L_aegis256_encrypt$8
 	vmovdqu	(%rsi,%r8), %xmm6
-	vpxor	%xmm4, %xmm1, %xmm7
-	vpand	%xmm3, %xmm2, %xmm8
-	vmovdqu	%xmm5, %xmm9
-	vpxor	%xmm8, %xmm7, %xmm5
-	vpxor	%xmm9, %xmm5, %xmm5
-	vpxor	%xmm5, %xmm6, %xmm7
-	vpxor	%xmm6, %xmm0, %xmm6
-	vaesenc	%xmm9, %xmm4, %xmm5
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm1, %xmm2
-	vaesenc	%xmm1, %xmm0, %xmm1
-	vaesenc	%xmm6, %xmm9, %xmm0
+	vpxor	%xmm1, %xmm4, %xmm7
+	vpand	%xmm2, %xmm3, %xmm8
+	vmovdqu	%xmm0, %xmm9
+	vpxor	%xmm8, %xmm7, %xmm0
+	vpxor	%xmm9, %xmm0, %xmm0
+	vpxor	%xmm0, %xmm6, %xmm7
+	vpxor	%xmm6, %xmm5, %xmm6
+	vaesenc	%xmm9, %xmm1, %xmm0
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm4, %xmm3
+	vaesenc	%xmm4, %xmm5, %xmm4
+	vaesenc	%xmm6, %xmm9, %xmm5
 	vmovdqu	%xmm7, (%rax,%r8)
 	addq	$-16, %rdi
 	addq	$16, %r8
@@ -675,7 +674,7 @@ L_aegis256_encrypt$8:
 	addq	%r8, %rax
 	vpxor	%xmm6, %xmm6, %xmm6
 	vmovdqu	%xmm6, (%rsp)
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis256_encrypt$6
 L_aegis256_encrypt$7:
 	movb	(%rsi,%r8), %r9b
@@ -685,21 +684,21 @@ L_aegis256_encrypt$6:
 	cmpq	%rdi, %r8
 	jb  	L_aegis256_encrypt$7
 	vmovdqu	(%rsp), %xmm6
-	vpxor	%xmm4, %xmm1, %xmm7
-	vpand	%xmm3, %xmm2, %xmm8
-	vmovdqu	%xmm5, %xmm9
-	vpxor	%xmm8, %xmm7, %xmm5
-	vpxor	%xmm9, %xmm5, %xmm5
-	vpxor	%xmm5, %xmm6, %xmm7
-	vpxor	%xmm6, %xmm0, %xmm6
-	vaesenc	%xmm9, %xmm4, %xmm5
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm1, %xmm2
-	vaesenc	%xmm1, %xmm0, %xmm1
-	vaesenc	%xmm6, %xmm9, %xmm0
+	vpxor	%xmm1, %xmm4, %xmm7
+	vpand	%xmm2, %xmm3, %xmm8
+	vmovdqu	%xmm0, %xmm9
+	vpxor	%xmm8, %xmm7, %xmm0
+	vpxor	%xmm9, %xmm0, %xmm0
+	vpxor	%xmm0, %xmm6, %xmm7
+	vpxor	%xmm6, %xmm5, %xmm6
+	vaesenc	%xmm9, %xmm1, %xmm0
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm4, %xmm3
+	vaesenc	%xmm4, %xmm5, %xmm4
+	vaesenc	%xmm6, %xmm9, %xmm5
 	vmovdqu	%xmm7, (%rsp)
-	xorq	%rsi, %rsi
+	xorl	%esi, %esi
 	jmp 	L_aegis256_encrypt$4
 L_aegis256_encrypt$5:
 	movb	(%rsp,%rsi), %r8b
@@ -711,75 +710,75 @@ L_aegis256_encrypt$4:
 L_aegis256_encrypt$3:
 	movq	24(%rsp), %rsi
 	movq	16(%rsp), %rdi
-	xorq	%rax, %rax
+	xorl	%eax, %eax
 	shlq	$3, %rsi
 	shlq	$3, %rdi
 	movq	%rsi, (%rsp)
 	movq	%rdi, 8(%rsp)
-	vpxor	(%rsp), %xmm3, %xmm6
-	vpxor	%xmm6, %xmm0, %xmm7
-	vaesenc	%xmm5, %xmm4, %xmm8
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm1, %xmm2
-	vaesenc	%xmm1, %xmm0, %xmm0
-	vaesenc	%xmm7, %xmm5, %xmm1
-	vpxor	%xmm6, %xmm1, %xmm5
-	vaesenc	%xmm8, %xmm4, %xmm7
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm0, %xmm2
-	vaesenc	%xmm0, %xmm1, %xmm0
-	vaesenc	%xmm5, %xmm8, %xmm1
-	vpxor	%xmm6, %xmm1, %xmm5
-	vaesenc	%xmm7, %xmm4, %xmm8
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm0, %xmm2
-	vaesenc	%xmm0, %xmm1, %xmm0
-	vaesenc	%xmm5, %xmm7, %xmm1
-	vpxor	%xmm6, %xmm1, %xmm5
-	vaesenc	%xmm8, %xmm4, %xmm7
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm0, %xmm2
-	vaesenc	%xmm0, %xmm1, %xmm0
-	vaesenc	%xmm5, %xmm8, %xmm1
-	vpxor	%xmm6, %xmm1, %xmm5
-	vaesenc	%xmm7, %xmm4, %xmm8
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm0, %xmm2
-	vaesenc	%xmm0, %xmm1, %xmm0
-	vaesenc	%xmm5, %xmm7, %xmm1
-	vpxor	%xmm6, %xmm1, %xmm5
-	vaesenc	%xmm8, %xmm4, %xmm7
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm0, %xmm2
-	vaesenc	%xmm0, %xmm1, %xmm1
+	vpxor	(%rsp), %xmm2, %xmm6
+	vpxor	%xmm6, %xmm5, %xmm7
+	vaesenc	%xmm0, %xmm1, %xmm8
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm4, %xmm3
+	vaesenc	%xmm4, %xmm5, %xmm4
+	vaesenc	%xmm7, %xmm0, %xmm0
+	vpxor	%xmm6, %xmm0, %xmm5
+	vaesenc	%xmm8, %xmm1, %xmm7
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm4, %xmm3
+	vaesenc	%xmm4, %xmm0, %xmm0
+	vaesenc	%xmm5, %xmm8, %xmm4
+	vpxor	%xmm6, %xmm4, %xmm5
+	vaesenc	%xmm7, %xmm1, %xmm8
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm0, %xmm3
+	vaesenc	%xmm0, %xmm4, %xmm0
+	vaesenc	%xmm5, %xmm7, %xmm4
+	vpxor	%xmm6, %xmm4, %xmm5
+	vaesenc	%xmm8, %xmm1, %xmm7
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm0, %xmm3
+	vaesenc	%xmm0, %xmm4, %xmm0
+	vaesenc	%xmm5, %xmm8, %xmm4
+	vpxor	%xmm6, %xmm4, %xmm5
+	vaesenc	%xmm7, %xmm1, %xmm8
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm0, %xmm3
+	vaesenc	%xmm0, %xmm4, %xmm0
+	vaesenc	%xmm5, %xmm7, %xmm4
+	vpxor	%xmm6, %xmm4, %xmm5
+	vaesenc	%xmm8, %xmm1, %xmm7
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm0, %xmm3
+	vaesenc	%xmm0, %xmm4, %xmm4
 	vaesenc	%xmm5, %xmm8, %xmm5
 	vpxor	%xmm6, %xmm5, %xmm6
-	vaesenc	%xmm7, %xmm4, %xmm0
-	vaesenc	%xmm4, %xmm3, %xmm4
-	vaesenc	%xmm3, %xmm2, %xmm3
-	vaesenc	%xmm2, %xmm1, %xmm2
-	vaesenc	%xmm1, %xmm5, %xmm1
+	vaesenc	%xmm7, %xmm1, %xmm0
+	vaesenc	%xmm1, %xmm2, %xmm1
+	vaesenc	%xmm2, %xmm3, %xmm2
+	vaesenc	%xmm3, %xmm4, %xmm3
+	vaesenc	%xmm4, %xmm5, %xmm4
 	vaesenc	%xmm6, %xmm7, %xmm5
 	cmpb	$16, %dl
 	je  	L_aegis256_encrypt$1
-	vpxor	%xmm1, %xmm5, %xmm1
-	vpxor	%xmm4, %xmm3, %xmm3
-	vpxor	%xmm2, %xmm1, %xmm1
-	vpxor	%xmm0, %xmm3, %xmm0
-	vmovdqu	%xmm1, (%rcx)
+	vpxor	%xmm4, %xmm5, %xmm4
+	vpxor	%xmm1, %xmm2, %xmm1
+	vpxor	%xmm3, %xmm4, %xmm2
+	vpxor	%xmm0, %xmm1, %xmm0
+	vmovdqu	%xmm2, (%rcx)
 	vmovdqu	%xmm0, 16(%rcx)
 	jmp 	L_aegis256_encrypt$2
 L_aegis256_encrypt$1:
-	vpxor	%xmm1, %xmm5, %xmm1
-	vpxor	%xmm2, %xmm1, %xmm1
-	vpxor	%xmm3, %xmm1, %xmm1
-	vpxor	%xmm4, %xmm1, %xmm1
+	vpxor	%xmm4, %xmm5, %xmm4
+	vpxor	%xmm3, %xmm4, %xmm3
+	vpxor	%xmm2, %xmm3, %xmm2
+	vpxor	%xmm1, %xmm2, %xmm1
 	vpxor	%xmm0, %xmm1, %xmm0
 	vmovdqu	%xmm0, (%rcx)
 L_aegis256_encrypt$2:

--- a/src/aegis256x2/aegis256x2.jazz
+++ b/src/aegis256x2/aegis256x2.jazz
@@ -83,7 +83,7 @@ inline fn declast(#secret reg u256[6] st, #public reg u256 t,
     pad[0] = out;
     reg u64 i = left;
     while (i < 32) {
-        pad[u8(int) i] = 0;
+        pad[:u8 i] = 0;
         i += 1;
     }
     st = update2(st, pad[0], st5);
@@ -107,10 +107,10 @@ inline fn init(#public reg u64 key_p, #public reg u64 nonce_p)
     #secret reg u128 k00 k10;
     #public reg u128 n00 n10;
 
-    k00 = (u128)[key_p];
-    k10 = (u128)[key_p + 16];
-    #declassify n00 = (u128)[nonce_p];
-    #declassify n10 = (u128)[nonce_p + 16];
+    k00 = [:u128 key_p];
+    k10 = [:u128 key_p + 16];
+    #declassify n00 = [:u128 nonce_p];
+    #declassify n10 = [:u128 nonce_p + 16];
     #secret reg u256 k0 k1;
     #public reg u256 n0 n1;
     k0 = #VINSERTI128(k0, k00, 0);
@@ -161,7 +161,8 @@ inline fn finalize(#secret reg u256[6] st,
                    #public inline bool verify)
     -> #secret reg u64
 {
-    reg u64 ret = #set0();
+    reg u64 ret;
+    ?{}, ret = #set0();
 
     stack u64[4] sizes;
     ad_len <<= 3;
@@ -170,7 +171,7 @@ inline fn finalize(#secret reg u256[6] st,
     sizes[2] = ad_len;
     sizes[1] = msg_len;
     sizes[3] = msg_len;
-    reg u256 t = st[3] ^ sizes[u256 0];
+    reg u256 t = st[3] ^ sizes[:u256 0];
 
     inline int i;
     for i = 0 to 7 {
@@ -191,14 +192,14 @@ inline fn finalize(#secret reg u256[6] st,
 
         if (verify) {
             reg u128 valid;
-            valid = (u128)[tag_p];
+            valid = [:u128 tag_p];
             valid = #VPCMPEQ_2u64(valid, tag);
-            ret = #VPMOVMSKB_u128u64(valid);
+            ret = (64u)#MOVEMASK_16u8(valid);
             ret += 1;
             ret >>= 16;
             ret -= 1;
         } else {
-            (u128)[tag_p] = tag;
+            [:u128 tag_p] = tag;
         }
     } else {
         reg u256[2] tag256;
@@ -215,18 +216,18 @@ inline fn finalize(#secret reg u256[6] st,
 
         if (verify) {
             reg u128[2] valid;
-            valid[0] = (u128)[tag_p];
-            valid[1] = (u128)[tag_p + 16];
+            valid[0] = [:u128 tag_p];
+            valid[1] = [:u128 tag_p + 16];
             valid[0] = #VPCMPEQ_2u64(valid[0], tag[0]);
             valid[1] = #VPCMPEQ_2u64(valid[1], tag[1]);
             valid[0] &= valid[1];
-            ret = #VPMOVMSKB_u128u64(valid[0]);
+            ret = (64u)#MOVEMASK_16u8(valid[0]);
             ret += 1;
             ret >>= 16;
             ret -= 1;
         } else {
-            (u128)[tag_p] = tag[0];
-            (u128)[tag_p + 16] = tag[1];
+            [:u128 tag_p] = tag[0];
+            [:u128 tag_p + 16] = tag[1];
         }
     }
     for i = 0 to 6 {
@@ -242,16 +243,16 @@ export fn _aegis256x2_encrypt(#public reg u64 params)
     #public stack u64 ad_len_ msg_len_;
     #public reg u8 tag_len;
 
-    #declassify ct_p = (u64)[params + 8 * 0];
-    // ignored: ct_len = (u64)[params + 8 * 1];
-    #declassify tag_p = (u64)[params + 8 * 2];
-    #declassify tag_len = (u8)[params + 8 * 3];
-    #declassify msg_p = (u64)[params + 8 * 4];
-    #declassify msg_len_ = (u64)[params + 8 * 5];
-    #declassify ad_p = (u64)[params + 8 * 6];
-    #declassify ad_len_ = (u64)[params + 8 * 7];
-    #declassify key_p = (u64)[params + 8 * 8];
-    #declassify nonce_p = (u64)[params + 8 * 9];
+    #declassify ct_p = [:u64 params + 8 * 0];
+    // ignored: ct_len = [:u64 :u64 params + 8 * 1];
+    #declassify tag_p = [:u64 params + 8 * 2];
+    #declassify tag_len = [:u8 params + 8 * 3];
+    #declassify msg_p = [:u64 params + 8 * 4];
+    #declassify msg_len_ = [:u64 params + 8 * 5];
+    #declassify ad_p = [:u64 params + 8 * 6];
+    #declassify ad_len_ = [:u64 params + 8 * 7];
+    #declassify key_p = [:u64 params + 8 * 8];
+    #declassify nonce_p = [:u64 params + 8 * 9];
 
     #secret reg u256[6] st;
     st = init(key_p, nonce_p);
@@ -262,10 +263,11 @@ export fn _aegis256x2_encrypt(#public reg u64 params)
     full_blocks = ad_len_;
     full_blocks = full_blocks & -32;
 
-    reg u64 i = #set0();
+    reg u64 i;
+    ?{}, i = #set0();
 
     #align while (i < full_blocks) {
-        st = absorb(st, (u256)[ad_p + i]);
+        st = absorb(st, [:u256 ad_p + i]);
         i += 32;
     }
     reg u64 left;
@@ -279,9 +281,9 @@ export fn _aegis256x2_encrypt(#public reg u64 params)
         reg u256 zero = #set0_256();
         pad[0] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[ad_p + i];
+            pad[:u8 i] = [:u8 ad_p + i];
             i += 1;
         }
         st = absorb(st, pad[0]);
@@ -292,16 +294,16 @@ export fn _aegis256x2_encrypt(#public reg u64 params)
     full_blocks = msg_len_;
     full_blocks = full_blocks & -64;
 
-    i = #set0();
+    ?{}, i = #set0();
     #align while (i < full_blocks) {
-        st, (u256)[ct_p + i] = enc(st, (u256)[msg_p + i]);
-        st, (u256)[ct_p + i + 32] = enc(st, (u256)[msg_p + i + 32]);
+        st, [:u256 ct_p + i] = enc(st, [:u256 msg_p + i]);
+        st, [:u256 ct_p + i + 32] = enc(st, [:u256 msg_p + i + 32]);
         i += 64;
     }
     left = msg_len_;
     left -= i;
     if (left >= 32) {
-        st, (u256)[ct_p + i] = enc(st, (u256)[msg_p + i]);
+        st, [:u256 ct_p + i] = enc(st, [:u256 msg_p + i]);
         left -= 32;
         i += 32;
     }
@@ -313,17 +315,17 @@ export fn _aegis256x2_encrypt(#public reg u64 params)
         reg u256 zero = #set0_256();
         pad[0] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[msg_p + i];
+            pad[:u8 i] = [:u8 msg_p + i];
             i += 1;
         }
 
         st, pad[0] = enc(st, pad[0]);
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            (u8)[ct_p + i] = pad[u8(int) i];
+            [:u8 ct_p + i] = pad[:u8 i];
             i += 1;
         }
     }
@@ -342,16 +344,16 @@ export fn _aegis256x2_decrypt(#public reg u64 params)
     #public stack u64 ad_len_ ct_len_;
     #public reg u8 tag_len;
 
-    #declassify ct_p = (u64)[params + 8 * 0];
-    #declassify ct_len_ = (u64)[params + 8 * 1];
-    #declassify tag_p = (u64)[params + 8 * 2];
-    #declassify tag_len = (u8)[params + 8 * 3];
-    #declassify msg_p = (u64)[params + 8 * 4];
-    // ignored: msg_len_ = (u64)[params + 8 * 5];
-    #declassify ad_p = (u64)[params + 8 * 6];
-    #declassify ad_len_ = (u64)[params + 8 * 7];
-    #declassify key_p = (u64)[params + 8 * 8];
-    #declassify nonce_p = (u64)[params + 8 * 9];
+    #declassify ct_p = [:u64 params + 8 * 0];
+    #declassify ct_len_ = [:u64 params + 8 * 1];
+    #declassify tag_p = [:u64 params + 8 * 2];
+    #declassify tag_len = [:u8 params + 8 * 3];
+    #declassify msg_p = [:u64 params + 8 * 4];
+    // ignored: msg_len_ = [:u64 params + 8 * 5];
+    #declassify ad_p = [:u64 params + 8 * 6];
+    #declassify ad_len_ = [:u64 params + 8 * 7];
+    #declassify key_p = [:u64 params + 8 * 8];
+    #declassify nonce_p = [:u64 params + 8 * 9];
 
     #secret reg u256[6] st;
     st = init(key_p, nonce_p);
@@ -362,9 +364,10 @@ export fn _aegis256x2_decrypt(#public reg u64 params)
     full_blocks = ad_len_;
     full_blocks = full_blocks & -32;
 
-    reg u64 i = #set0();
+    reg u64 i;
+    ?{}, i = #set0();
     #align while (i < full_blocks) {
-        st = absorb(st, (u256)[ad_p + i]);
+        st = absorb(st, [:u256 ad_p + i]);
         i += 32;
     }
     reg u64 left;
@@ -378,9 +381,9 @@ export fn _aegis256x2_decrypt(#public reg u64 params)
         reg u256 zero = #set0_256();
         pad[0] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[ad_p + i];
+            pad[:u8 i] = [:u8 ad_p + i];
             i += 1;
         }
 
@@ -392,21 +395,21 @@ export fn _aegis256x2_decrypt(#public reg u64 params)
     full_blocks = ct_len_;
     full_blocks = full_blocks & -64;
 
-    i = #set0();
+    ?{}, i = #set0();
     #align while (i < full_blocks) {
         #public reg u256 t;
-        #declassify t = (u256)[ct_p + i];
-        st, (u256)[msg_p + i] = dec(st, t);
-        #declassify t = (u256)[ct_p + i + 32];
-        st, (u256)[msg_p + i + 32] = dec(st, t);
+        #declassify t = [:u256 ct_p + i];
+        st, [:u256 msg_p + i] = dec(st, t);
+        #declassify t = [:u256 ct_p + i + 32];
+        st, [:u256 msg_p + i + 32] = dec(st, t);
         i += 64;
     }
     left = ct_len_;
     left -= i;
     if (left > 32) {
         #public reg u256 t;
-        #declassify t = (u256)[ct_p + i];
-        st, (u256)[msg_p + i] = dec(st, t);
+        #declassify t = [:u256 ct_p + i];
+        st, [:u256 msg_p + i] = dec(st, t);
         left -= 32;
         i += 32;
     }
@@ -418,9 +421,9 @@ export fn _aegis256x2_decrypt(#public reg u64 params)
         reg u256 zero = #set0_256();
         pad[0] = zero;
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            pad[u8(int) i] = (u8)[ct_p + i];
+            pad[:u8 i] = [:u8 ct_p + i];
             i += 1;
         }
 
@@ -429,9 +432,9 @@ export fn _aegis256x2_decrypt(#public reg u64 params)
 
         st, pad[0] = declast(st, t, left);
 
-        i = #set0();
+        ?{}, i = #set0();
         while (i < left) {
-            (u8)[msg_p + i] = pad[u8(int) i];
+            [:u8 msg_p + i] = pad[:u8 i];
             i += 1;
         }
     }

--- a/src/aegis256x2/aegis256x2.s
+++ b/src/aegis256x2/aegis256x2.s
@@ -1,10 +1,10 @@
 	.att_syntax
 	.text
 	.p2align	5
-	.globl	__aegis256x2_decrypt
-	.globl	_aegis256x2_decrypt
-	.globl	__aegis256x2_encrypt
-	.globl	_aegis256x2_encrypt
+	.global	__aegis256x2_decrypt
+	.global	_aegis256x2_decrypt
+	.global	__aegis256x2_encrypt
+	.global	_aegis256x2_encrypt
 __aegis256x2_decrypt:
 _aegis256x2_decrypt:
 	movq	%rsp, %r11
@@ -190,32 +190,31 @@ _aegis256x2_decrypt:
 	vaesenc	%ymm6, %ymm1, %ymm6
 	vaesenc	%ymm1, %ymm4, %ymm1
 	vaesenc	%ymm4, %ymm5, %ymm2
-	vaesenc	%ymm8, %ymm7, %ymm7
+	vaesenc	%ymm8, %ymm7, %ymm5
 	vpxor	glob_data + 0(%rip), %ymm6, %ymm4
-	vpxor	glob_data + 0(%rip), %ymm9, %ymm5
-	vmovdqu	%ymm5, %ymm8
-	vpxor	%ymm3, %ymm7, %ymm9
-	vaesenc	%ymm8, %ymm0, %ymm6
-	vaesenc	%ymm0, %ymm4, %ymm5
+	vpxor	glob_data + 0(%rip), %ymm9, %ymm6
+	vpxor	%ymm3, %ymm5, %ymm7
+	vaesenc	%ymm6, %ymm0, %ymm3
+	vaesenc	%ymm0, %ymm4, %ymm0
 	vaesenc	%ymm4, %ymm1, %ymm4
-	vaesenc	%ymm1, %ymm2, %ymm3
-	vaesenc	%ymm2, %ymm7, %ymm0
-	vaesenc	%ymm9, %ymm8, %ymm1
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm5, %ymm2
+	vaesenc	%ymm7, %ymm6, %ymm5
 	movq	72(%rsp), %rdi
 	andq	$-32, %rdi
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis256x2_decrypt$16
 	.p2align	5
 L_aegis256x2_decrypt$17:
-	vmovdqu	(%r8,%r9), %ymm2
-	vmovdqu	%ymm6, %ymm7
-	vpxor	%ymm2, %ymm1, %ymm2
-	vaesenc	%ymm7, %ymm5, %ymm6
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm0, %ymm3
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm2, %ymm7, %ymm1
+	vmovdqu	(%r8,%r9), %ymm6
+	vmovdqu	%ymm3, %ymm7
+	vpxor	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm7, %ymm0, %ymm3
+	vaesenc	%ymm0, %ymm4, %ymm0
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm5, %ymm2
+	vaesenc	%ymm6, %ymm7, %ymm5
 	addq	$32, %r9
 L_aegis256x2_decrypt$16:
 	cmpq	%rdi, %r9
@@ -225,9 +224,9 @@ L_aegis256x2_decrypt$16:
 	cmpq	$0, %rdi
 	jbe 	L_aegis256x2_decrypt$13
 	addq	%r9, %r8
-	vpxor	%ymm2, %ymm2, %ymm2
-	vmovdqu	%ymm2, (%rsp)
-	xorq	%r9, %r9
+	vpxor	%ymm6, %ymm6, %ymm6
+	vmovdqu	%ymm6, (%rsp)
+	xorl	%r9d, %r9d
 	jmp 	L_aegis256x2_decrypt$14
 L_aegis256x2_decrypt$15:
 	movb	(%r8,%r9), %r10b
@@ -236,49 +235,49 @@ L_aegis256x2_decrypt$15:
 L_aegis256x2_decrypt$14:
 	cmpq	%rdi, %r9
 	jb  	L_aegis256x2_decrypt$15
-	vmovdqu	(%rsp), %ymm2
-	vmovdqu	%ymm6, %ymm7
-	vpxor	%ymm2, %ymm1, %ymm2
-	vaesenc	%ymm7, %ymm5, %ymm6
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm0, %ymm3
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm2, %ymm7, %ymm1
+	vmovdqu	(%rsp), %ymm6
+	vmovdqu	%ymm3, %ymm7
+	vpxor	%ymm6, %ymm5, %ymm6
+	vaesenc	%ymm7, %ymm0, %ymm3
+	vaesenc	%ymm0, %ymm4, %ymm0
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm5, %ymm2
+	vaesenc	%ymm6, %ymm7, %ymm5
 L_aegis256x2_decrypt$13:
 	movq	64(%rsp), %rdi
 	andq	$-64, %rdi
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis256x2_decrypt$11
 	.p2align	5
 L_aegis256x2_decrypt$12:
-	vmovdqu	(%rax,%r8), %ymm2
-	vpxor	%ymm5, %ymm0, %ymm7
-	vpand	%ymm4, %ymm3, %ymm8
+	vmovdqu	(%rax,%r8), %ymm6
+	vpxor	%ymm0, %ymm2, %ymm7
+	vpand	%ymm4, %ymm1, %ymm8
+	vpxor	%ymm8, %ymm7, %ymm7
+	vpxor	%ymm3, %ymm7, %ymm7
+	vpxor	%ymm7, %ymm6, %ymm7
+	vpxor	%ymm7, %ymm5, %ymm8
+	vaesenc	%ymm3, %ymm0, %ymm6
+	vaesenc	%ymm0, %ymm4, %ymm0
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm5, %ymm2
+	vaesenc	%ymm8, %ymm3, %ymm5
+	vmovdqu	%ymm7, (%rsi,%r8)
+	vmovdqu	32(%rax,%r8), %ymm3
+	vpxor	%ymm0, %ymm2, %ymm7
+	vpand	%ymm4, %ymm1, %ymm8
 	vpxor	%ymm8, %ymm7, %ymm7
 	vpxor	%ymm6, %ymm7, %ymm7
-	vpxor	%ymm7, %ymm2, %ymm7
-	vpxor	%ymm7, %ymm1, %ymm8
-	vaesenc	%ymm6, %ymm5, %ymm2
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm0, %ymm3
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm8, %ymm6, %ymm1
-	vmovdqu	%ymm7, (%rsi,%r8)
-	vmovdqu	32(%rax,%r8), %ymm6
-	vpxor	%ymm5, %ymm0, %ymm7
-	vpand	%ymm4, %ymm3, %ymm8
-	vpxor	%ymm8, %ymm7, %ymm7
-	vpxor	%ymm2, %ymm7, %ymm7
-	vpxor	%ymm7, %ymm6, %ymm7
-	vpxor	%ymm7, %ymm1, %ymm8
-	vaesenc	%ymm2, %ymm5, %ymm6
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm0, %ymm3
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm8, %ymm2, %ymm1
+	vpxor	%ymm7, %ymm3, %ymm7
+	vpxor	%ymm7, %ymm5, %ymm8
+	vaesenc	%ymm6, %ymm0, %ymm3
+	vaesenc	%ymm0, %ymm4, %ymm0
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm5, %ymm2
+	vaesenc	%ymm8, %ymm6, %ymm5
 	vmovdqu	%ymm7, 32(%rsi,%r8)
 	addq	$64, %r8
 L_aegis256x2_decrypt$11:
@@ -288,21 +287,21 @@ L_aegis256x2_decrypt$11:
 	subq	%r8, %rdi
 	cmpq	$32, %rdi
 	jbe 	L_aegis256x2_decrypt$10
-	vmovdqu	(%rax,%r8), %ymm2
-	vpxor	%ymm5, %ymm0, %ymm7
-	vpand	%ymm4, %ymm3, %ymm8
-	vmovdqu	%ymm6, %ymm9
-	vpxor	%ymm8, %ymm7, %ymm6
-	vpxor	%ymm9, %ymm6, %ymm6
-	vpxor	%ymm6, %ymm2, %ymm2
-	vpxor	%ymm2, %ymm1, %ymm7
-	vaesenc	%ymm9, %ymm5, %ymm6
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm0, %ymm3
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm7, %ymm9, %ymm1
-	vmovdqu	%ymm2, (%rsi,%r8)
+	vmovdqu	(%rax,%r8), %ymm6
+	vpxor	%ymm0, %ymm2, %ymm7
+	vpand	%ymm4, %ymm1, %ymm8
+	vmovdqu	%ymm3, %ymm9
+	vpxor	%ymm8, %ymm7, %ymm3
+	vpxor	%ymm9, %ymm3, %ymm3
+	vpxor	%ymm3, %ymm6, %ymm6
+	vpxor	%ymm6, %ymm5, %ymm7
+	vaesenc	%ymm9, %ymm0, %ymm3
+	vaesenc	%ymm0, %ymm4, %ymm0
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm5, %ymm2
+	vaesenc	%ymm7, %ymm9, %ymm5
+	vmovdqu	%ymm6, (%rsi,%r8)
 	addq	$-32, %rdi
 	addq	$32, %r8
 L_aegis256x2_decrypt$10:
@@ -310,9 +309,9 @@ L_aegis256x2_decrypt$10:
 	jbe 	L_aegis256x2_decrypt$3
 	addq	%r8, %rsi
 	addq	%r8, %rax
-	vpxor	%ymm2, %ymm2, %ymm2
-	vmovdqu	%ymm2, (%rsp)
-	xorq	%r8, %r8
+	vpxor	%ymm6, %ymm6, %ymm6
+	vmovdqu	%ymm6, (%rsp)
+	xorl	%r8d, %r8d
 	jmp 	L_aegis256x2_decrypt$8
 L_aegis256x2_decrypt$9:
 	movb	(%rax,%r8), %r9b
@@ -321,14 +320,14 @@ L_aegis256x2_decrypt$9:
 L_aegis256x2_decrypt$8:
 	cmpq	%rdi, %r8
 	jb  	L_aegis256x2_decrypt$9
-	vmovdqu	(%rsp), %ymm2
-	vpxor	%ymm5, %ymm0, %ymm7
-	vpand	%ymm4, %ymm3, %ymm8
-	vmovdqu	%ymm6, %ymm9
-	vpxor	%ymm8, %ymm7, %ymm6
-	vpxor	%ymm9, %ymm6, %ymm6
-	vpxor	%ymm6, %ymm2, %ymm2
-	vmovdqu	%ymm2, 32(%rsp)
+	vmovdqu	(%rsp), %ymm6
+	vpxor	%ymm0, %ymm2, %ymm7
+	vpand	%ymm4, %ymm1, %ymm8
+	vmovdqu	%ymm3, %ymm9
+	vpxor	%ymm8, %ymm7, %ymm3
+	vpxor	%ymm9, %ymm3, %ymm3
+	vpxor	%ymm3, %ymm6, %ymm6
+	vmovdqu	%ymm6, 32(%rsp)
 	movq	%rdi, %rax
 	jmp 	L_aegis256x2_decrypt$6
 L_aegis256x2_decrypt$7:
@@ -337,16 +336,16 @@ L_aegis256x2_decrypt$7:
 L_aegis256x2_decrypt$6:
 	cmpq	$32, %rax
 	jb  	L_aegis256x2_decrypt$7
-	vmovdqu	32(%rsp), %ymm6
-	vpxor	%ymm6, %ymm1, %ymm7
-	vaesenc	%ymm9, %ymm5, %ymm6
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm0, %ymm3
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm7, %ymm9, %ymm1
-	vmovdqu	%ymm2, (%rsp)
-	xorq	%rax, %rax
+	vmovdqu	32(%rsp), %ymm3
+	vpxor	%ymm3, %ymm5, %ymm7
+	vaesenc	%ymm9, %ymm0, %ymm3
+	vaesenc	%ymm0, %ymm4, %ymm0
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm5, %ymm2
+	vaesenc	%ymm7, %ymm9, %ymm5
+	vmovdqu	%ymm6, (%rsp)
+	xorl	%eax, %eax
 	jmp 	L_aegis256x2_decrypt$4
 L_aegis256x2_decrypt$5:
 	movb	(%rsp,%rax), %r8b
@@ -358,69 +357,68 @@ L_aegis256x2_decrypt$4:
 L_aegis256x2_decrypt$3:
 	movq	72(%rsp), %rax
 	movq	64(%rsp), %rsi
-	xorq	%rdi, %rdi
 	shlq	$3, %rax
 	shlq	$3, %rsi
 	movq	%rax, (%rsp)
 	movq	%rax, 16(%rsp)
 	movq	%rsi, 8(%rsp)
 	movq	%rsi, 24(%rsp)
-	vpxor	(%rsp), %ymm4, %ymm2
-	vpxor	%ymm2, %ymm1, %ymm7
-	vaesenc	%ymm6, %ymm5, %ymm8
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm0, %ymm3
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm7, %ymm6, %ymm1
-	vpxor	%ymm2, %ymm1, %ymm6
-	vaesenc	%ymm8, %ymm5, %ymm7
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm0, %ymm3
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm6, %ymm8, %ymm1
-	vpxor	%ymm2, %ymm1, %ymm6
-	vaesenc	%ymm7, %ymm5, %ymm8
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm0, %ymm3
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm6, %ymm7, %ymm1
-	vpxor	%ymm2, %ymm1, %ymm6
-	vaesenc	%ymm8, %ymm5, %ymm7
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm0, %ymm3
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm6, %ymm8, %ymm1
-	vpxor	%ymm2, %ymm1, %ymm6
-	vaesenc	%ymm7, %ymm5, %ymm8
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm0, %ymm3
-	vaesenc	%ymm0, %ymm1, %ymm0
-	vaesenc	%ymm6, %ymm7, %ymm1
-	vpxor	%ymm2, %ymm1, %ymm6
-	vaesenc	%ymm8, %ymm5, %ymm7
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm0, %ymm3
-	vaesenc	%ymm0, %ymm1, %ymm1
-	vaesenc	%ymm6, %ymm8, %ymm6
-	vpxor	%ymm2, %ymm6, %ymm2
-	vaesenc	%ymm7, %ymm5, %ymm0
-	vaesenc	%ymm5, %ymm4, %ymm5
-	vaesenc	%ymm4, %ymm3, %ymm4
-	vaesenc	%ymm3, %ymm1, %ymm3
-	vaesenc	%ymm1, %ymm6, %ymm1
-	vaesenc	%ymm2, %ymm7, %ymm2
+	vpxor	(%rsp), %ymm4, %ymm6
+	vpxor	%ymm6, %ymm5, %ymm7
+	vaesenc	%ymm3, %ymm0, %ymm8
+	vaesenc	%ymm0, %ymm4, %ymm0
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm5, %ymm2
+	vaesenc	%ymm7, %ymm3, %ymm3
+	vpxor	%ymm6, %ymm3, %ymm5
+	vaesenc	%ymm8, %ymm0, %ymm7
+	vaesenc	%ymm0, %ymm4, %ymm0
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm3, %ymm2
+	vaesenc	%ymm5, %ymm8, %ymm3
+	vpxor	%ymm6, %ymm3, %ymm5
+	vaesenc	%ymm7, %ymm0, %ymm8
+	vaesenc	%ymm0, %ymm4, %ymm0
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm3, %ymm2
+	vaesenc	%ymm5, %ymm7, %ymm3
+	vpxor	%ymm6, %ymm3, %ymm5
+	vaesenc	%ymm8, %ymm0, %ymm7
+	vaesenc	%ymm0, %ymm4, %ymm0
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm3, %ymm2
+	vaesenc	%ymm5, %ymm8, %ymm3
+	vpxor	%ymm6, %ymm3, %ymm5
+	vaesenc	%ymm7, %ymm0, %ymm8
+	vaesenc	%ymm0, %ymm4, %ymm0
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm3, %ymm2
+	vaesenc	%ymm5, %ymm7, %ymm3
+	vpxor	%ymm6, %ymm3, %ymm5
+	vaesenc	%ymm8, %ymm0, %ymm7
+	vaesenc	%ymm0, %ymm4, %ymm9
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm3, %ymm2
+	vaesenc	%ymm5, %ymm8, %ymm3
+	vpxor	%ymm6, %ymm3, %ymm5
+	vaesenc	%ymm7, %ymm9, %ymm0
+	vaesenc	%ymm9, %ymm4, %ymm6
+	vaesenc	%ymm4, %ymm1, %ymm4
+	vaesenc	%ymm1, %ymm2, %ymm1
+	vaesenc	%ymm2, %ymm3, %ymm2
+	vaesenc	%ymm5, %ymm7, %ymm3
 	cmpb	$16, %dl
 	je  	L_aegis256x2_decrypt$1
+	vpxor	%ymm2, %ymm3, %ymm2
+	vpxor	%ymm6, %ymm4, %ymm3
 	vpxor	%ymm1, %ymm2, %ymm1
-	vpxor	%ymm5, %ymm4, %ymm2
-	vpxor	%ymm3, %ymm1, %ymm1
-	vpxor	%ymm0, %ymm2, %ymm0
+	vpxor	%ymm0, %ymm3, %ymm0
 	vextracti128	$1, %ymm1, %xmm2
 	vextracti128	$1, %ymm0, %xmm3
 	vpxor	%xmm1, %xmm2, %xmm1
@@ -430,25 +428,25 @@ L_aegis256x2_decrypt$3:
 	vpcmpeqq	%xmm1, %xmm2, %xmm1
 	vpcmpeqq	%xmm0, %xmm3, %xmm0
 	vpand	%xmm0, %xmm1, %xmm0
-	vpmovmskb	%xmm0, %rax
+	vpmovmskb	%xmm0, %eax
 	incq	%rax
 	shrq	$16, %rax
-	addq	$-1, %rax
+	decq	%rax
 	jmp 	L_aegis256x2_decrypt$2
 L_aegis256x2_decrypt$1:
+	vpxor	%ymm2, %ymm3, %ymm2
 	vpxor	%ymm1, %ymm2, %ymm1
-	vpxor	%ymm3, %ymm1, %ymm1
 	vpxor	%ymm4, %ymm1, %ymm1
-	vpxor	%ymm5, %ymm1, %ymm1
+	vpxor	%ymm6, %ymm1, %ymm1
 	vpxor	%ymm0, %ymm1, %ymm0
 	vextracti128	$1, %ymm0, %xmm1
 	vpxor	%xmm0, %xmm1, %xmm0
 	vmovdqu	(%rcx), %xmm1
 	vpcmpeqq	%xmm0, %xmm1, %xmm0
-	vpmovmskb	%xmm0, %rax
+	vpmovmskb	%xmm0, %eax
 	incq	%rax
 	shrq	$16, %rax
-	addq	$-1, %rax
+	decq	%rax
 L_aegis256x2_decrypt$2:
 	movq	%r11, %rsp
 	movq	%rsp, %rsi
@@ -660,7 +658,7 @@ _aegis256x2_encrypt:
 	vaesenc	%ymm7, %ymm6, %ymm5
 	movq	40(%rsp), %rdi
 	andq	$-32, %rdi
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis256x2_encrypt$14
 	.p2align	5
 L_aegis256x2_encrypt$15:
@@ -684,7 +682,7 @@ L_aegis256x2_encrypt$14:
 	addq	%r9, %r8
 	vpxor	%ymm6, %ymm6, %ymm6
 	vmovdqu	%ymm6, (%rsp)
-	xorq	%r9, %r9
+	xorl	%r9d, %r9d
 	jmp 	L_aegis256x2_encrypt$12
 L_aegis256x2_encrypt$13:
 	movb	(%r8,%r9), %r10b
@@ -705,7 +703,7 @@ L_aegis256x2_encrypt$12:
 L_aegis256x2_encrypt$11:
 	movq	32(%rsp), %rdi
 	andq	$-64, %rdi
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis256x2_encrypt$9
 	.p2align	5
 L_aegis256x2_encrypt$10:
@@ -769,7 +767,7 @@ L_aegis256x2_encrypt$8:
 	addq	%r8, %rax
 	vpxor	%ymm6, %ymm6, %ymm6
 	vmovdqu	%ymm6, (%rsp)
-	xorq	%r8, %r8
+	xorl	%r8d, %r8d
 	jmp 	L_aegis256x2_encrypt$6
 L_aegis256x2_encrypt$7:
 	movb	(%rsi,%r8), %r9b
@@ -793,7 +791,7 @@ L_aegis256x2_encrypt$6:
 	vaesenc	%ymm2, %ymm5, %ymm2
 	vaesenc	%ymm6, %ymm9, %ymm5
 	vmovdqu	%ymm7, (%rsp)
-	xorq	%rsi, %rsi
+	xorl	%esi, %esi
 	jmp 	L_aegis256x2_encrypt$4
 L_aegis256x2_encrypt$5:
 	movb	(%rsp,%rsi), %r8b
@@ -805,7 +803,7 @@ L_aegis256x2_encrypt$4:
 L_aegis256x2_encrypt$3:
 	movq	40(%rsp), %rsi
 	movq	32(%rsp), %rdi
-	xorq	%rax, %rax
+	xorl	%eax, %eax
 	shlq	$3, %rsi
 	shlq	$3, %rdi
 	movq	%rsi, (%rsp)


### PR DESCRIPTION
In case contributions to this repository are welcome, here are a few changes —mostly syntactic— to the jasmin code, reflecting recent updates to the language and its compiler.

The `#set0()` intrinsics returns boolean values that must be explicitly ignored: `?{}, x = #set0();`

Array indices need not be explicitly cast to int.

The `#VPMOVMSKB` intrinsics is subsumed by `#MOVEMASK`.

The syntax for array accesses and memory accesses has changed: both get the (optional) size annotation inside the square brackets and signaled by a colon (e.g., `k = [:u128 key_p];`).

Assembly listings have been regenerated.